### PR TITLE
Apply tactile mode to text inputs

### DIFF
--- a/frontend/src/components/ClavierTexteModal.jsx
+++ b/frontend/src/components/ClavierTexteModal.jsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { Modal, Button } from 'react-bootstrap';
+
+function ClavierTexteModal({ show, onClose, onValider, initial = '' }) {
+  const [value, setValue] = useState(initial);
+
+  const handleInput = (char) => {
+    if (char === '←') {
+      setValue(prev => prev.slice(0, -1));
+    } else if (char === 'SPACE') {
+      setValue(prev => prev + ' ');
+    } else {
+      setValue(prev => prev + char);
+    }
+  };
+
+  const valider = () => {
+    onValider(value);
+    onClose();
+    setValue('');
+  };
+
+  const rows = [
+    ['1','2','3','4','5','6','7','8','9','0'],
+    ['A','Z','E','R','T','Y','U','I','O','P'],
+    ['Q','S','D','F','G','H','J','K','L','M'],
+    ['W','X','C','V','B','N']
+  ];
+
+  return (
+    <Modal show={show} onHide={onClose} centered>
+      <Modal.Header closeButton>
+        <Modal.Title>Saisie</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <div className="display-6 text-center mb-2">{value || ' '}</div>
+        {rows.map((row, idx) => (
+          <div key={idx} className="d-flex justify-content-center mb-1">
+            {row.map(char => (
+              <Button
+                key={char}
+                className="m-1"
+                variant="outline-primary"
+                style={{ width: 45 }}
+                onClick={() => handleInput(char)}
+              >
+                {char}
+              </Button>
+            ))}
+          </div>
+        ))}
+        <div className="d-flex justify-content-center">
+          <Button
+            className="m-1"
+            variant="outline-primary"
+            style={{ width: 90 }}
+            onClick={() => handleInput('SPACE')}
+          >
+            Espace
+          </Button>
+          <Button
+            className="m-1"
+            variant="outline-primary"
+            style={{ width: 45 }}
+            onClick={() => handleInput('←')}
+          >
+            ←
+          </Button>
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="success" onClick={valider}>Valider</Button>
+        <Button variant="secondary" onClick={onClose}>Annuler</Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}
+
+export default ClavierTexteModal;

--- a/frontend/src/components/CorrectionModal.jsx
+++ b/frontend/src/components/CorrectionModal.jsx
@@ -3,6 +3,7 @@ import { Modal, Button, Form } from 'react-bootstrap';
 import CategorieSelector from './CategorieSelector';
 import BoutonsCaisse from './BoutonsCaisse';
 import { useSessionCaisse } from '../contexts/SessionCaisseContext';
+import TactileInput from './TactileInput';
 
 
 function CorrectionModal({ show, onHide, ticketOriginal, onSuccess }) {
@@ -258,14 +259,16 @@ function CorrectionModal({ show, onHide, ticketOriginal, onSuccess }) {
             return (
               <div className="d-flex gap-2 mb-2" key={i}>
                 <Form.Control value={art.nom} disabled />
-                <Form.Control
+                <TactileInput
                   type="number"
+                  className="form-control"
                   value={art.nbr}
                   onChange={(e) => handleChange(i, 'nbr', e.target.value)}
                   disabled={isReduction}
                 />
-                <Form.Control
+                <TactileInput
                   type="number"
+                  className="form-control"
                   step="0.01"
                   value={(art.prix / 100).toFixed(2)}
                   onChange={(e) => handleChange(i, 'prix', e.target.value)}
@@ -310,8 +313,9 @@ function CorrectionModal({ show, onHide, ticketOriginal, onSuccess }) {
                   <option value="chèque">Chèque</option>
                   <option value="virement">Virement</option>
                 </Form.Select>
-                <Form.Control
-                  type="text"
+                <TactileInput
+                  type="number"
+                  className="form-control"
                   placeholder="Montant en euros"
                   value={p.montant}
                   onChange={e => modifierPaiement(index, 'montant', e.target.value)}

--- a/frontend/src/components/TactileInput.jsx
+++ b/frontend/src/components/TactileInput.jsx
@@ -1,0 +1,51 @@
+import React, { useState, useContext } from 'react';
+import ClavierNumeriqueModal from './clavierNumeriqueModal';
+import ClavierTexteModal from './ClavierTexteModal';
+import { ModeTactileContext } from '../App';
+
+function TactileInput({ value, onChange, type = 'text', isDecimal = false, ...props }) {
+  const { modeTactile } = useContext(ModeTactileContext);
+  const [show, setShow] = useState(false);
+
+  const handleValider = (val) => {
+    onChange({ target: { value: val } });
+  };
+
+  const isNumeric = type === 'number' || isDecimal;
+
+  if (modeTactile) {
+    const displayValue = value === undefined || value === null ? '' : value;
+    return (
+      <>
+        <input
+          {...props}
+          type={type === 'password' ? 'password' : 'text'}
+          readOnly
+          value={displayValue}
+          onClick={() => setShow(true)}
+          style={{ cursor: 'pointer', ...(props.style || {}) }}
+        />
+        {isNumeric ? (
+          <ClavierNumeriqueModal
+            show={show}
+            onClose={() => setShow(false)}
+            onValider={handleValider}
+            initial={displayValue.toString()}
+            isDecimal={true}
+          />
+        ) : (
+          <ClavierTexteModal
+            show={show}
+            onClose={() => setShow(false)}
+            onValider={handleValider}
+            initial={displayValue.toString()}
+          />
+        )}
+      </>
+    );
+  }
+
+  return <input {...props} type={type} value={value} onChange={onChange} />;
+}
+
+export default TactileInput;

--- a/frontend/src/components/TicketVente.jsx
+++ b/frontend/src/components/TicketVente.jsx
@@ -1,13 +1,7 @@
-import React, { useRef, useState, useContext } from 'react';
-import ClavierNumeriqueModal from './clavierNumeriqueModal';
-import { ModeTactileContext } from '../App'; // adapte le chemin si besoin
+import React from 'react';
+import TactileInput from './TactileInput';
 
 function TicketVente({ ticket, onChange, onDelete, onSave }) {
-  const total = ticket.reduce((sum, item) => sum + (item.prixt || 0), 0);
-  const prixRef = useRef({});
-  const nbrRef = useRef({});
-  const [modal, setModal] = useState({ show: false, id: null, type: null });
-  const { modeTactile } = useContext(ModeTactileContext);
 
   const handleSavePrix = async (id, rawValue) => {
     console.log("✅ Prix utilisé :", rawValue);
@@ -73,71 +67,24 @@ function TicketVente({ ticket, onChange, onDelete, onSave }) {
                 </div>
                 <div className="d-flex align-items-center">
                   {/* Champ quantité */}
-                  {modeTactile ? (
-                    <input
-                      type="text"
-                      readOnly
-                      value={item.nbr}
-                      ref={el => nbrRef.current[item.id] = el}
-                      onClick={() => setModal({ show: true, id: item.id, type: 'nbr' })}
-                      className="form-control form-control-sm mx-1"
-                      style={{ width: "50px", cursor: 'pointer' }}
-                    />
-                  ) : (
-                    <input
-                      type="number"
-                      defaultValue={item.nbr}
-                      ref={el => nbrRef.current[item.id] = el}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
-                          e.preventDefault();
-                          const raw = nbrRef.current[item.id]?.value;
-                          handleSaveQuantite(item.id, raw);
-                        }
-                      }}
-                      className="form-control form-control-sm mx-1"
-                      style={{ width: "50px" }}
-                    />
-                  )}
+                  <TactileInput
+                    type="number"
+                    className="form-control form-control-sm mx-1"
+                    style={{ width: "50px" }}
+                    value={item.nbr}
+                    onChange={(e) => handleSaveQuantite(item.id, e.target.value)}
+                  />
 
                   {/* Champ prix */}
-                  {modeTactile ? (
-                    <input
-                      type="text"
-                      readOnly
-                      value={prixAffiché}
-                      ref={el => prixRef.current[item.id] = el}
-                      onClick={() => setModal({ show: true, id: item.id, type: 'prix' })}
-                      className="form-control form-control-sm"
-                      style={{ width: "70px", cursor: 'pointer' }}
-                    />
-                  ) : (
-                    <input
-                      type="text"
-                      defaultValue={prixAffiché}
-                      ref={el => prixRef.current[item.id] = el}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
-                          e.preventDefault();
-                          const raw = prixRef.current[item.id]?.value;
-                          handleSavePrix(item.id, raw);
-                        }
-                      }}
-                      className="form-control form-control-sm"
-                      style={{ width: "70px" }}
-                    />
-                  )}
+                  <TactileInput
+                    type="number"
+                    className="form-control form-control-sm"
+                    style={{ width: "70px" }}
+                    value={prixAffiché}
+                    onChange={(e) => handleSavePrix(item.id, e.target.value)}
+                  />
 
-                  <button
-                    className="btn btn-sm btn-success ms-1"
-                    onClick={() => {
-                      const raw = prixRef.current[item.id]?.value;
-                      handleSavePrix(item.id, raw);
-                    }}
-                    title="Sauvegarder prix"
-                  >
-                    💾
-                  </button>
+                  
                   <span className="ms-2">{(item.prixt / 100).toFixed(2)} €</span>
                 </div>
               </div>
@@ -146,23 +93,7 @@ function TicketVente({ ticket, onChange, onDelete, onSave }) {
         })}
       </ul>
 
-      <div className="mt-2">
-        <ClavierNumeriqueModal
-          show={modal.show}
-          onClose={() => setModal({ show: false, id: null, type: null })}
-          isDecimal={modal.type === 'prix'}
-          initial=""
-          onValider={async (val) => {
-            const id = modal.id;
-            if (modal.type === 'prix') {
-              await handleSavePrix(id, val);
-            } else if (modal.type === 'nbr') {
-              await handleSaveQuantite(id, val);
-            }
-            setModal({ show: false, id: null, type: null });
-          }}
-        />
-      </div>
+      
     </>
   );
 }

--- a/frontend/src/components/ValidationVente.jsx
+++ b/frontend/src/components/ValidationVente.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import TactileInput from './TactileInput';
 import { useSessionCaisse } from '../contexts/SessionCaisseContext';
 
 function ValidationVente({ total, id_temp_vente, onValide }) {
@@ -160,15 +161,15 @@ function ValidationVente({ total, id_temp_vente, onValide }) {
       <div className="d-flex justify-content-between align-items-start mb-2">
         <h5 className="me-3">Finaliser la vente</h5>
         <div className="d-flex gap-2">
-          <input
-            type="text"
+          <TactileInput
+            type="number"
             className="form-control form-control-sm"
             style={{ maxWidth: '100px' }}
             placeholder="Code postal"
             value={codePostal}
             onChange={e => setCodePostal(e.target.value)}
           />
-          <input
+          <TactileInput
             type="email"
             className="form-control form-control-sm"
             style={{ maxWidth: '180px' }}
@@ -206,8 +207,8 @@ function ValidationVente({ total, id_temp_vente, onValide }) {
               <option value="chèque">Chèque</option>
               <option value="virement">Virement</option>
             </select>
-            <input
-              type="text"
+            <TactileInput
+              type="number"
               className="form-control me-2"
               placeholder="Montant en euros"
               value={p.montant}

--- a/frontend/src/components/compteEspeces.jsx
+++ b/frontend/src/components/compteEspeces.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import TactileInput from './TactileInput';
 
 const valeurs = [
   { label: '1 cts', value: 0.01, colonne: 'centimes' },
@@ -91,12 +92,13 @@ function CompteEspeces({ onChangeTotal }) {
               <td style={{ width: '70px' }}>{centimes[i]?.label || ''}</td>
               <td>
                 {centimes[i] &&
-                  <input
+                  <TactileInput
                     type="number"
                     min="0"
+                    className="form-control"
+                    style={{ width: '50px' }}
                     value={quantites[centimes[i].value]}
                     onChange={(e) => handleChange(centimes[i].value, e.target.value)}
-                    style={{ width: '50px' }}
                   />}
               </td>
 
@@ -104,12 +106,13 @@ function CompteEspeces({ onChangeTotal }) {
               <td style={{ width: '70px', borderLeft: '1px solid #ccc' }}>{billets[i]?.label || ''}</td>
               <td>
                 {billets[i] &&
-                  <input
+                  <TactileInput
                     type="number"
                     min="0"
+                    className="form-control"
+                    style={{ width: '50px' }}
                     value={quantites[billets[i].value]}
                     onChange={(e) => handleChange(billets[i].value, e.target.value)}
-                    style={{ width: '50px' }}
                   />}
               </td>
 
@@ -117,12 +120,13 @@ function CompteEspeces({ onChangeTotal }) {
               <td style={{ width: '70px', borderLeft: '1px solid #ccc' }}>{gros[i]?.label || ''}</td>
               <td>
                 {gros[i] &&
-                  <input
+                  <TactileInput
                     type="number"
                     min="0"
+                    className="form-control"
+                    style={{ width: '50px' }}
                     value={quantites[gros[i].value]}
                     onChange={(e) => handleChange(gros[i].value, e.target.value)}
-                    style={{ width: '50px' }}
                   />}
               </td>
             </tr>

--- a/frontend/src/pages/BilanTickets.jsx
+++ b/frontend/src/pages/BilanTickets.jsx
@@ -6,6 +6,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import './BilanTickets.css';
 import TicketDetail from '../components/TicketDetail';
 import CorrectionModal from '../components/CorrectionModal';
+import TactileInput from '../components/TactileInput';
 import { Button } from 'react-bootstrap';
 import { useLocation } from 'react-router-dom';
 import { toast, ToastContainer } from 'react-toastify';
@@ -234,7 +235,7 @@ const location = useLocation();
         </div>
         <div className="modal-body">
           <label className="form-label">Adresse e-mail :</label>
-          <input
+          <TactileInput
             type="email"
             className="form-control"
             value={emailDestinataire}

--- a/frontend/src/pages/FermetureCaisse.jsx
+++ b/frontend/src/pages/FermetureCaisse.jsx
@@ -4,6 +4,7 @@ import { toast, ToastContainer } from 'react-toastify';
 import CompteEspeces from '../components/compteEspeces';
 import AffichageEcarts from '../components/AffichageEcarts';
 import BilanSessionCaisse from '../components/BilanSessionCaisse';
+import TactileInput from '../components/TactileInput';
 import { useSessionCaisse } from '../contexts/SessionCaisseContext';
 
 // Composant principal pour la fermeture de caisse
@@ -147,7 +148,7 @@ function FermetureCaisse() {
           <div></div>
           <div>
             <label>Montant réel dans la caisse (€) :</label><br />
-            <input
+            <TactileInput
               type="number"
               value={montantReel}
               onChange={(e) => setMontantReel(e.target.value)}
@@ -156,7 +157,7 @@ function FermetureCaisse() {
           </div>
           <div>
             <label>Montant réel des transactions Sumup (€) :</label><br />
-            <input
+            <TactileInput
               type="number"
               value={montantReelCarte}
               onChange={(e) => setMontantReelCarte(e.target.value)}
@@ -165,7 +166,7 @@ function FermetureCaisse() {
           </div>
           <div>
             <label>Montant réel des chèques (€) :</label><br />
-            <input
+            <TactileInput
               type="number"
               value={montantReelCheque}
               onChange={(e) => setMontantReelCheque(e.target.value)}
@@ -174,7 +175,7 @@ function FermetureCaisse() {
           </div>
           <div>
             <label>Montant réel des virement (€) :</label><br />
-            <input
+            <TactileInput
               type="number"
               value={montantReelVirement}
               onChange={(e) => setMontantReelVirement(e.target.value)}
@@ -206,7 +207,7 @@ function FermetureCaisse() {
           </div>
           <div>
             <label>Pseudo du responsable :</label><br />
-            <input
+            <TactileInput
               type="text"
               value={responsablePseudo}
               onChange={(e) => setResponsablePseudo(e.target.value)}
@@ -215,7 +216,7 @@ function FermetureCaisse() {
           </div>
           <div>
             <label>Mot de passe du responsable :</label><br />
-            <input
+            <TactileInput
               type="password"
               value={motDePasse}
               onChange={(e) => setMotDePasse(e.target.value)}

--- a/frontend/src/pages/ouvertureCaisse.jsx
+++ b/frontend/src/pages/ouvertureCaisse.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import CompteEspeces from '../components/compteEspeces';
+import TactileInput from '../components/TactileInput';
 import { useSessionCaisse } from '../contexts/SessionCaisseContext';
 
 
@@ -59,7 +60,7 @@ function OuvertureCaisse() {
         <CompteEspeces onChangeTotal={(total) => setFondInitial(total)} />
         <div>
           <label>Fond de caisse initial (€) :</label><br />
-          <input
+          <TactileInput
             type="number"
             value={fondInitial}
             onChange={(e) => setFondInitial(e.target.value)}
@@ -68,7 +69,7 @@ function OuvertureCaisse() {
         </div>
         <div>
           <label>Pseudo du responsable :</label><br />
-          <input
+          <TactileInput
             type="text"
             value={responsablePseudo}
             onChange={(e) => setResponsablePseudo(e.target.value)}
@@ -77,7 +78,7 @@ function OuvertureCaisse() {
         </div>
         <div>
           <label>Mot de passe du responsable :</label><br />
-          <input
+          <TactileInput
             type="password"
             value={motDePasse}
             onChange={(e) => setMotDePasse(e.target.value)}


### PR DESCRIPTION
## Summary
- implement `ClavierTexteModal` to display an alphabetic keyboard
- update `TactileInput` to open numeric or text keyboards based on the field type
- use `TactileInput` for responsible credentials on cash closing and opening forms
- use `TactileInput` for email fields and correction modal inputs
- refactor `TicketVente` to rely on `TactileInput` for quantity and price

## Testing
- `npm test` in `backend` *(fails: cross-env not found)*
- `npm test --silent` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68458b12d9b883278aec55b4913b0774