### PR TITLE
Add caisse journal feature

### DIFF
--- a/backend/routes/OuvertureCaisse.routes.js
+++ b/backend/routes/OuvertureCaisse.routes.js
@@ -79,4 +79,17 @@ if (!motDePasseValide) {
    res.json({ success: true, id_session });
 });
 
+router.get('/journal', (req, res) => {
+  try {
+    const sessions = sqlite.prepare(`
+      SELECT * FROM session_caisse
+      ORDER BY date_ouverture DESC, heure_ouverture DESC
+    `).all();
+    res.json(sessions);
+  } catch (err) {
+    console.error('Erreur récupération journal caisse:', err);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
 module.exports = router;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,11 +1,13 @@
 import { io } from 'socket.io-client';
 import React, { useEffect, useState, createContext } from 'react';
 import { Routes, Route, Link, useNavigate } from 'react-router-dom'; // ✅ ajout de useNavigate
+import { Navbar, Nav } from 'react-bootstrap';
 import Caisse from './pages/Caisse';
 import BilanTickets from './pages/BilanTickets';
 import LoginPage from './pages/LoginPage';
 import OuvertureCaisse from './pages/ouvertureCaisse';
 import FermetureCaisse from './pages/FermetureCaisse';
+import JournalCaisse from './pages/JournalCaisse';
 import RequireSession from './components/RequireSession';
 import './styles/App.scss';
 import { ToastContainer, toast } from 'react-toastify';
@@ -65,14 +67,21 @@ function App() {
   return (
     <ModeTactileContext.Provider value={{ modeTactile, setModeTactile }}>
       <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', overflow: 'hidden' }}>
-        <nav className="navbar navbar-expand navbar-dark bg-dark px-3">
-          <Link className="navbar-brand" to="/">Caisse</Link>
-          <Link className="nav-link text-white" to="/bilan">Bilan tickets</Link>
-          {caisseOuverte ? (
-            <Link className="nav-link text-white" to="/fermeture-caisse">Fermeture Caisse</Link>
-          ) : (
-            <Link className="nav-link text-white" to="/ouverture-caisse">Ouverture Caisse</Link>
-          )}
+        <Navbar bg="dark" variant="dark" expand={false} className="px-3">
+          <Navbar.Brand as={Link} to="/">Caisse</Navbar.Brand>
+          <Navbar.Toggle aria-controls="main-nav" />
+          <Navbar.Collapse id="main-nav">
+            <Nav className="flex-column">
+              <Nav.Link as={Link} to="/">Caisse</Nav.Link>
+              <Nav.Link as={Link} to="/bilan">Bilan tickets</Nav.Link>
+              {caisseOuverte ? (
+                <Nav.Link as={Link} to="/fermeture-caisse">Fermeture Caisse</Nav.Link>
+              ) : (
+                <Nav.Link as={Link} to="/ouverture-caisse">Ouverture Caisse</Nav.Link>
+              )}
+              <Nav.Link as={Link} to="/journal-caisse">Journal caisse</Nav.Link>
+            </Nav>
+          </Navbar.Collapse>
 
 
           {bilanJour && (
@@ -178,7 +187,7 @@ function App() {
               </label>
             </div>
           </div>
-        </nav>
+        </Navbar>
 
         <div style={{ flex: 1, overflow: 'hidden' }}>
           <Routes>
@@ -187,6 +196,7 @@ function App() {
             <Route path="/bilan" element={<RequireSession><BilanTickets /></RequireSession>} />
             <Route path="/ouverture-caisse" element={<RequireSession><OuvertureCaisse /></RequireSession>} />
             <Route path="/fermeture-caisse" element={<RequireSession><FermetureCaisse /></RequireSession>} />
+            <Route path="/journal-caisse" element={<RequireSession><JournalCaisse /></RequireSession>} />
 
           </Routes>
         </div>

--- a/frontend/src/pages/JournalCaisse.jsx
+++ b/frontend/src/pages/JournalCaisse.jsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+import 'bootstrap/dist/css/bootstrap.min.css';
+
+function formatEuros(val) {
+  return val != null ? `${(val / 100).toFixed(2)} €` : '—';
+}
+
+const JournalCaisse = () => {
+  const [sessions, setSessions] = useState([]);
+
+  useEffect(() => {
+    fetch('http://localhost:3001/api/caisse/journal')
+      .then(res => res.json())
+      .then(setSessions)
+      .catch(err => console.error('Erreur chargement journal caisse:', err));
+  }, []);
+
+  return (
+    <div className="container mt-3">
+      <h2>Journal de caisse</h2>
+      <table className="table table-striped">
+        <thead>
+          <tr>
+            <th>Ouverture</th>
+            <th>Fermeture</th>
+            <th>Resp. ouverture</th>
+            <th>Resp. fermeture</th>
+            <th>Fond initial</th>
+            <th>Montant réel</th>
+            <th>Écart</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sessions.map(s => (
+            <tr key={s.id_session}>
+              <td>{s.date_ouverture} {s.heure_ouverture}</td>
+              <td>{s.date_fermeture ? `${s.date_fermeture} ${s.heure_fermeture}` : '—'}</td>
+              <td>{s.responsable_ouverture || '—'}</td>
+              <td>{s.responsable_fermeture || '—'}</td>
+              <td>{formatEuros(s.fond_initial)}</td>
+              <td>{s.montant_reel != null ? formatEuros(s.montant_reel) : '—'}</td>
+              <td>{s.ecart != null ? formatEuros(s.ecart) : '—'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default JournalCaisse;


### PR DESCRIPTION
## Summary
- add API endpoint to list `session_caisse`
- create JournalCaisse page to display sessions
- show navbar items inside a hamburger menu

## Testing
- `npm test` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a87371f48327b8d88e09ab3dda91