### PR TITLE
Add caisse journal feature

### DIFF
--- a/backend/routes/OuvertureCaisse.routes.js
+++ b/backend/routes/OuvertureCaisse.routes.js
@@ -79,4 +79,17 @@ if (!motDePasseValide) {
    res.json({ success: true, id_session });
 });
 
+router.get('/journal', (req, res) => {
+  try {
+    const sessions = sqlite.prepare(`
+      SELECT * FROM session_caisse
+      ORDER BY date_ouverture DESC, heure_ouverture DESC
+    `).all();
+    res.json(sessions);
+  } catch (err) {
+    console.error('Erreur récupération journal caisse:', err);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
 module.exports = router;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,11 +1,13 @@
 import { io } from 'socket.io-client';
 import React, { useEffect, useState, createContext } from 'react';
 import { Routes, Route, Link, useNavigate } from 'react-router-dom'; // ✅ ajout de useNavigate
+import { Navbar, Nav } from 'react-bootstrap';
 import Caisse from './pages/Caisse';
 import BilanTickets from './pages/BilanTickets';
 import LoginPage from './pages/LoginPage';
 import OuvertureCaisse from './pages/ouvertureCaisse';
 import FermetureCaisse from './pages/FermetureCaisse';
+import JournalCaisse from './pages/JournalCaisse';
 import RequireSession from './components/RequireSession';
 import './styles/App.scss';
 import { ToastContainer, toast } from 'react-toastify';
@@ -65,14 +67,21 @@ function App() {
   return (
     <ModeTactileContext.Provider value={{ modeTactile, setModeTactile }}>
       <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', overflow: 'hidden' }}>
-        <nav className="navbar navbar-expand navbar-dark bg-dark px-3">
-          <Link className="navbar-brand" to="/">Caisse</Link>
-          <Link className="nav-link text-white" to="/bilan">Bilan tickets</Link>
-          {caisseOuverte ? (
-            <Link className="nav-link text-white" to="/fermeture-caisse">Fermeture Caisse</Link>
-          ) : (
-            <Link className="nav-link text-white" to="/ouverture-caisse">Ouverture Caisse</Link>
-          )}
+        <Navbar bg="dark" variant="dark" expand={false} className="px-3">
+          <Navbar.Brand as={Link} to="/">Caisse</Navbar.Brand>
+          <Navbar.Toggle aria-controls="main-nav" />
+          <Navbar.Collapse id="main-nav">
+            <Nav className="flex-column">
+              <Nav.Link as={Link} to="/">Caisse</Nav.Link>
+              <Nav.Link as={Link} to="/bilan">Bilan tickets</Nav.Link>
+              {caisseOuverte ? (
+                <Nav.Link as={Link} to="/fermeture-caisse">Fermeture Caisse</Nav.Link>
+              ) : (
+                <Nav.Link as={Link} to="/ouverture-caisse">Ouverture Caisse</Nav.Link>
+              )}
+              <Nav.Link as={Link} to="/journal-caisse">Journal caisse</Nav.Link>
+            </Nav>
+          </Navbar.Collapse>
 
 
           {bilanJour && (
@@ -178,7 +187,7 @@ function App() {
               </label>
             </div>
           </div>
-        </nav>
+        </Navbar>
 
         <div style={{ flex: 1, overflow: 'hidden' }}>
           <Routes>
@@ -187,6 +196,7 @@ function App() {
             <Route path="/bilan" element={<RequireSession><BilanTickets /></RequireSession>} />
             <Route path="/ouverture-caisse" element={<RequireSession><OuvertureCaisse /></RequireSession>} />
             <Route path="/fermeture-caisse" element={<RequireSession><FermetureCaisse /></RequireSession>} />
+            <Route path="/journal-caisse" element={<RequireSession><JournalCaisse /></RequireSession>} />
 
           </Routes>
         </div>

--- a/frontend/src/components/SessionDetails.jsx
+++ b/frontend/src/components/SessionDetails.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+function formatEuros(val) {
+  return val != null ? `${(val / 100).toFixed(2)} €` : '—';
+}
+
+const SessionDetails = ({ session, bilan }) => {
+  if (!session || !bilan) return <div>Chargement...</div>;
+
+  const caissiers = session.caissiers ? JSON.parse(session.caissiers) : [];
+
+  const attendu = {
+    espece: (bilan.prix_total_espece ?? 0) + (session.fond_initial ?? 0),
+    carte: bilan.prix_total_carte ?? 0,
+    cheque: bilan.prix_total_cheque ?? 0,
+    virement: bilan.prix_total_virement ?? 0,
+  };
+
+  const ecarts = {
+    espece: (session.montant_reel ?? 0) - attendu.espece,
+    carte: (session.montant_reel_carte ?? 0) - attendu.carte,
+    cheque: (session.montant_reel_cheque ?? 0) - attendu.cheque,
+    virement: (session.montant_reel_virement ?? 0) - attendu.virement,
+  };
+
+  return (
+    <div className="p-3 border bg-white rounded">
+      <p><strong>Caissiers :</strong> {caissiers.join(', ') || '—'}</p>
+      <table className="table table-sm">
+        <thead>
+          <tr>
+            <th>Moyen</th>
+            <th>Attendu</th>
+            <th>Réel</th>
+            <th>Écart</th>
+          </tr>
+        </thead>
+        <tbody>
+          {['espece', 'carte', 'cheque', 'virement'].map(m => (
+            <tr key={m}>
+              <td style={{ textTransform: 'capitalize' }}>{m}</td>
+              <td>{formatEuros(attendu[m])}</td>
+              <td>{formatEuros(session[`montant_reel_${m}`] ?? (m === 'espece' ? session.montant_reel : 0))}</td>
+              <td>{formatEuros(ecarts[m])}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default SessionDetails;

--- a/frontend/src/pages/JournalCaisse.jsx
+++ b/frontend/src/pages/JournalCaisse.jsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from 'react';
+import SessionDetails from '../components/SessionDetails';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import './BilanTickets.css';
+
+function formatEuros(val) {
+  return val != null ? `${(val / 100).toFixed(2)} €` : '—';
+}
+
+const JournalCaisse = () => {
+  const [sessions, setSessions] = useState([]);
+  const [details, setDetails] = useState({});
+  const [active, setActive] = useState(null);
+
+  useEffect(() => {
+    fetch('http://localhost:3001/api/caisse/journal')
+      .then(res => res.json())
+      .then(setSessions)
+      .catch(err => console.error('Erreur chargement journal caisse:', err));
+  }, []);
+
+  const chargerDetails = (session) => {
+    const id = session.id_session;
+    if (details[id]) {
+      setActive(active === id ? null : id);
+      return;
+    }
+    fetch(`http://localhost:3001/api/bilan/bilan_session_caisse?uuid_session_caisse=${id}`)
+      .then(res => res.json())
+      .then(bilan => {
+        setDetails(prev => ({ ...prev, [id]: bilan }));
+        setActive(id);
+      })
+      .catch(err => console.error('Erreur chargement bilan session:', err));
+  };
+
+  return (
+    <div className="bilan-scroll-container">
+      <div className="container">
+        <h2>Journal de caisse</h2>
+        <table className="table table-striped mt-3">
+          <thead>
+            <tr>
+              <th>Ouverture</th>
+              <th>Fermeture</th>
+              <th>Resp. ouverture</th>
+              <th>Resp. fermeture</th>
+              <th>Écart total</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sessions.map(s => (
+              <React.Fragment key={s.id_session}>
+                <tr
+                  onClick={() => chargerDetails(s)}
+                  style={{ cursor: 'pointer' }}
+                  className={active === s.id_session ? 'table-active' : ''}
+                >
+                  <td>{s.date_ouverture} {s.heure_ouverture}</td>
+                  <td>{s.date_fermeture ? `${s.date_fermeture} ${s.heure_fermeture}` : '—'}</td>
+                  <td>{s.responsable_ouverture || '—'}</td>
+                  <td>{s.responsable_fermeture || '—'}</td>
+                  <td>{s.ecart != null ? formatEuros(s.ecart) : '—'}</td>
+                </tr>
+                {active === s.id_session && details[s.id_session] && (
+                  <tr>
+                    <td colSpan="5">
+                      <SessionDetails session={s} bilan={details[s.id_session]} />
+                    </td>
+                  </tr>
+                )}
+              </React.Fragment>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default JournalCaisse;


### PR DESCRIPTION
## Summary
- add API endpoint to list `session_caisse`
- create JournalCaisse page to display sessions
- show navbar items inside a hamburger menu
- add SessionDetails component to expand each session row with cashiers and totals
- integrate expansion logic in JournalCaisse page

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a87371f48327b8d88e09ab3dda91