### PR TITLE
Affiche ticket lié dans badges de corrections

### DIFF
--- a/backend/routes/bilan.routes.js
+++ b/backend/routes/bilan.routes.js
@@ -8,8 +8,10 @@ const getBilanSession = require('../utils/bilanSession');
 router.get('/', (req, res) => {
   try {
     const tickets = sqlite.prepare(`
-      SELECT 
-        t.*, 
+      SELECT
+        t.*,
+        jc_annul.id_ticket_original AS annulation_de,
+        jc_corr.id_ticket_original  AS correction_de,
         EXISTS (
           SELECT 1 FROM journal_corrections jc WHERE jc.id_ticket_original = t.id_ticket
         ) AS ticket_corrige,
@@ -17,6 +19,8 @@ router.get('/', (req, res) => {
           SELECT 1 FROM journal_corrections jc WHERE jc.id_ticket_correction = t.id_ticket
         ) AS est_correction
       FROM ticketdecaisse t
+      LEFT JOIN journal_corrections jc_annul ON jc_annul.id_ticket_annulation = t.id_ticket
+      LEFT JOIN journal_corrections jc_corr  ON jc_corr.id_ticket_correction  = t.id_ticket
       ORDER BY t.id_ticket DESC
     `).all();
 

--- a/frontend/src/pages/BilanTickets.jsx
+++ b/frontend/src/pages/BilanTickets.jsx
@@ -149,11 +149,11 @@ const location = useLocation();
                     <td>{aReduction(ticket) ? '✅' : '—'}</td>
                     <td>
                       {ticket.flag_correction ? (
-                        <span className="badge bg-danger">Annulation</span>
+                        <span className="badge bg-danger">Annulation de #{ticket.annulation_de}</span>
+                      ) : ticket.corrige_le_ticket ? (
+                        <span className="badge bg-info text-dark">Correction de #{ticket.correction_de}</span>
                       ) : ticket.correction_de ? (
                         <span className="badge bg-warning text-dark">Correctif</span>
-                      ) : ticket.corrige_le_ticket ? (
-                        <span className="badge bg-info text-dark">Correction</span>
                       ) : ticket.cloture === 1 ? (
                         <span className="badge bg-info text-dark">Cloture Caisse</span>
                       ) : (


### PR DESCRIPTION
## Summary
- expose related ticket ids in `/api/bilan`
- display ticket numbers in annulation/correction badges

## Testing
- `npm test` in `backend` *(fails: cross-env not found)*
- `npm test --silent` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d459aa7c8327bee9fc4931593182