### PR TITLE
Add caissier update on login

### DIFF
--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 function LoginPage() {
   const [users, setUsers] = useState([]);
   const [selected, setSelected] = useState('');
+  const [sessionOuverte, setSessionOuverte] = useState(false);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -11,28 +12,49 @@ function LoginPage() {
       .then(res => res.json())
       .then(setUsers)
       .catch(err => console.error('Erreur chargement utilisateurs:', err));
+
+    fetch('http://localhost:3001/api/session/etat-caisse')
+      .then(res => res.json())
+      .then(data => setSessionOuverte(data.ouverte))
+      .catch(err => console.error('Erreur état caisse:', err));
   }, []);
 
-  const handleLogin = () => {
+  const handleLogin = async () => {
     if (!selected) return;
-    fetch('http://localhost:3001/api/session', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ pseudo: selected })
-    })
-      .then(res => res.json())
-      .then(data => {
-        if (data.success) {
-          localStorage.setItem('vendeur', JSON.stringify(data.user));
-          navigate('/'); // ✅ navigation propre pour Electron
+    try {
+      const res = await fetch('http://localhost:3001/api/session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pseudo: selected })
+      });
+      const data = await res.json();
+      if (data.success) {
+        localStorage.setItem('vendeur', JSON.stringify(data.user));
+
+        try {
+          const etatRes = await fetch('http://localhost:3001/api/session/etat-caisse');
+          const etat = await etatRes.json();
+          if (etat.ouverte) {
+            await fetch('http://localhost:3001/api/session/ajouter-caissier', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ nom: data.user.nom })
+            });
+          }
+        } catch (err) {
+          console.error('Erreur mise à jour caissiers:', err);
         }
-      })
-      .catch(() => alert('Erreur de connexion'));
+
+        navigate('/'); // ✅ navigation propre pour Electron
+      }
+    } catch (err) {
+      alert('Erreur de connexion');
+    }
   };
 
   return (
     <div className="container mt-5">
-      <h2>Connexion vendeur</h2>
+      <h2>{sessionOuverte ? 'Changement de caissier' : 'Connexion vendeur'}</h2>
       <select className="form-select my-3" onChange={e => setSelected(e.target.value)} value={selected}>
         <option value="">-- Choisir un vendeur --</option>
         {users.map(u => (


### PR DESCRIPTION
## Summary
- add endpoint to append caissier to current session
- update login page to call new endpoint when a session is open
- show "Changement de caissier" when a session is active

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd backend && npm test` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849de29bef4832788c3811177e54f9f