### PR TITLE
Fix missing logSync calls

### DIFF
--- a/backend/routes/OuvertureCaisse.routes.js
+++ b/backend/routes/OuvertureCaisse.routes.js
@@ -56,8 +56,8 @@ if (!motDePasseValide) {
 
   sqlite.prepare(`
     INSERT INTO session_caisse (
-      id_session, date_ouverture, heure_ouverture, 
-      utilisateur_ouverture, responsable_ouverture, 
+      id_session, date_ouverture, heure_ouverture,
+      utilisateur_ouverture, responsable_ouverture,
       fond_initial, caissiers
     )
     VALUES (?, ?, ?, ?, ?, ?, ?)
@@ -70,6 +70,16 @@ if (!motDePasseValide) {
     fond_initial,
     caissiers
   );
+
+  logSync('session_caisse', 'INSERT', {
+    id_session,
+    date_ouverture,
+    heure_ouverture,
+    utilisateur_ouverture: utilisateur.nom,
+    responsable_ouverture: responsable.nom,
+    fond_initial,
+    caissiers
+  });
 
 
   const io = req.app.get('socketio');

--- a/backend/routes/correction.routes.js
+++ b/backend/routes/correction.routes.js
@@ -201,7 +201,14 @@ console.log(req.body);
       uuid_session_caisse
     });
 
-    sqlite.prepare('UPDATE ticketdecaisse SET corrige_le_ticket = ? WHERE id_ticket = ?').run(id_ticket_original, id_corrige);
+    sqlite.prepare('UPDATE ticketdecaisse SET corrige_le_ticket = ? WHERE id_ticket = ?').run(
+      id_ticket_original,
+      id_corrige
+    );
+    logSync('ticketdecaisse', 'UPDATE', {
+      id_ticket: id_corrige,
+      corrige_le_ticket: id_ticket_original
+    });
 
     let pmCorrige = { espece: 0, carte: 0, cheque: 0, virement: 0 };
     const normalisation = {

--- a/backend/routes/session.routes.js
+++ b/backend/routes/session.routes.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const { sqlite } = require('../db');
 const bcrypt = require('bcrypt');
 const session = require('../session');
+const logSync = require('../logsync');
 
 
 // Connexion avec vérification du mot de passe
@@ -76,6 +77,11 @@ router.post('/ajouter-caissier', (req, res) => {
     sqlite
       .prepare('UPDATE session_caisse SET caissiers = ? WHERE id_session = ?')
       .run(JSON.stringify(caissiers), sessionCaisse.id_session);
+
+    logSync('session_caisse', 'UPDATE', {
+      id_session: sessionCaisse.id_session,
+      caissiers: JSON.stringify(caissiers)
+    });
   }
 
   res.json({ success: true, caissiers });

--- a/backend/routes/validerVente.routes.js
+++ b/backend/routes/validerVente.routes.js
@@ -243,7 +243,14 @@ router.post('/', (req, res) => {
 
 
 
-    sqlite.prepare('UPDATE ticketdecaisse SET lien = ? WHERE id_ticket = ?').run(`tickets/Ticket-${uuid_ticket}.txt`, id_ticket);
+    sqlite.prepare('UPDATE ticketdecaisse SET lien = ? WHERE id_ticket = ?').run(
+      `tickets/Ticket-${uuid_ticket}.txt`,
+      id_ticket
+    );
+    logSync('ticketdecaisse', 'UPDATE', {
+      id_ticket,
+      lien: `tickets/Ticket-${uuid_ticket}.txt`
+    });
     sqlite.prepare('DELETE FROM vente WHERE id_temp_vente = ?').run(id_temp_vente);
     sqlite.prepare('DELETE FROM ticketdecaissetemp WHERE id_temp_vente = ?').run(id_temp_vente);
 


### PR DESCRIPTION
## Summary
- logSync is now called after updating ticket link in `validerVente.routes.js`
- added logging when creating a cash session in `OuvertureCaisse.routes.js`
- added logging for cashier updates in `session.routes.js`
- recorded updates when linking corrected tickets in `correction.routes.js`

## Testing
- `npm test` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_685024fa35948327985aed2c305cd7bf