### PR TITLE
Ajout synchro périodique

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -21,6 +21,7 @@ const syncRoutes = require('./routes/sync.routes');
 const envoiTicket = require('./routes/envoiTicket.routes');
 const compareSchemasRoutes = require('./routes/compareSchemas.routes');
 const dbConfigRoutes = require('./routes/dbconfig.routes');
+const syncConfigRoutes = require('./routes/syncConfig.routes');
 
 
 
@@ -44,6 +45,7 @@ app.use('/api/caisse', require('./routes/ouvertureCaisse.routes'));
 app.use('/api/caisse/fermeture', require('./routes/FermetureCaisse.routes'));
 app.use('/api/compare-schemas', compareSchemasRoutes);
 app.use('/api/dbconfig', dbConfigRoutes);
+app.use('/api/sync-config', syncConfigRoutes);
 
 
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -2,6 +2,7 @@
 const http = require('http');
 const app = require('./app');
 const PORT = process.env.PORT || 3001;
+const { startScheduler } = require('./syncScheduler');
 
 const server = http.createServer(app);
 const io = require('socket.io')(server, {
@@ -12,4 +13,5 @@ app.set('socketio', io);
 
 server.listen(PORT, () => {
   console.log(`Serveur backend lancé sur http://localhost:${PORT}`);
+  startScheduler(PORT, io);
 });

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
         "pdfkit": "^0.17.1",
         "socket.io": "^4.8.1",
         "uuid": "^11.1.0"
+        ,"node-cron": "^3.0.2"
     },
     "devDependencies": {
         "cross-env": "^7.0.3",

--- a/backend/routes/sync.routes.js
+++ b/backend/routes/sync.routes.js
@@ -3,6 +3,8 @@ const router = express.Router();
 const { sqlite, mysql } = require('../db');
 
 router.post('/', async (req, res) => {
+  const io = req.app.get('socketio');
+  if (io) io.emit('syncStart');
   try {
     const lignes = sqlite.prepare(`SELECT * FROM sync_log WHERE synced = 0`).all();
 
@@ -131,6 +133,8 @@ router.post('/', async (req, res) => {
   } catch (err) {
     console.error('Erreur de synchronisation :', err);
     res.status(500).json({ error: 'Erreur de synchronisation.' });
+  } finally {
+    if (io) io.emit('syncEnd');
   }
 });
 

--- a/backend/routes/syncConfig.routes.js
+++ b/backend/routes/syncConfig.routes.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const router = express.Router();
+const { updateConfig, getConfig } = require('../syncScheduler');
+
+router.get('/', (req, res) => {
+  res.json(getConfig());
+});
+
+router.post('/', (req, res) => {
+  const { interval, enabled } = req.body || {};
+  const minutes = parseInt(interval, 10);
+  if (!minutes || minutes <= 0) {
+    return res.status(400).json({ error: 'Interval invalide' });
+  }
+  updateConfig(minutes, typeof enabled === 'boolean' ? enabled : undefined);
+  res.json({ success: true });
+});
+
+module.exports = router;

--- a/backend/syncConfig.json
+++ b/backend/syncConfig.json
@@ -1,0 +1,4 @@
+{
+  "interval": 60,
+  "enabled": true
+}

--- a/backend/syncScheduler.js
+++ b/backend/syncScheduler.js
@@ -1,0 +1,58 @@
+const path = require('path');
+const fs = require('fs');
+const axios = require('axios');
+const cron = require('node-cron');
+
+const configPath = path.join(__dirname, 'syncConfig.json');
+
+function loadConfig() {
+  if (fs.existsSync(configPath)) {
+    try {
+      const data = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      const interval =
+        typeof data.interval === 'number' && data.interval > 0 ? data.interval : 60;
+      const enabled = typeof data.enabled === 'boolean' ? data.enabled : true;
+      return { interval, enabled };
+    } catch {}
+  }
+  return { interval: 60, enabled: true };
+}
+
+let { interval, enabled } = loadConfig();
+let job = null;
+let port = 3001;
+let io = null;
+
+async function callSync() {
+  try {
+    await axios.post(`http://localhost:${port}/api/sync/`);
+    console.log('✅ Synchronisation périodique exécutée');
+  } catch (err) {
+    console.error('Erreur de synchronisation périodique:', err.message);
+  }
+}
+
+function scheduleJob() {
+  if (job) job.stop();
+  if (!enabled) return;
+  job = cron.schedule(`*/${interval} * * * *`, callSync);
+}
+
+function startScheduler(p, ioInstance) {
+  port = p || port;
+  io = ioInstance || io;
+  scheduleJob();
+}
+
+function updateConfig(newInterval, newEnabled) {
+  if (newInterval && newInterval > 0) interval = newInterval;
+  if (typeof newEnabled === 'boolean') enabled = newEnabled;
+  fs.writeFileSync(configPath, JSON.stringify({ interval, enabled }, null, 2));
+  scheduleJob();
+}
+
+function getConfig() {
+  return { interval, enabled };
+}
+
+module.exports = { startScheduler, updateConfig, getConfig };

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -10,6 +10,7 @@ import FermetureCaisse from './pages/FermetureCaisse';
 import JournalCaisse from './pages/JournalCaisse';
 import CompareSchemas from './pages/CompareSchemas';
 import DbConfig from './pages/DbConfig';
+import Parametres from './pages/Parametres';
 import RequireSession from './components/RequireSession';
 import './styles/App.scss';
 import 'react-toastify/dist/ReactToastify.css';
@@ -31,6 +32,18 @@ function App() {
   });
   const [caisseOuverte, setCaisseOuverte] = useState(false);
   const [showMenu, setShowMenu] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+
+  useEffect(() => {
+    const startHandler = () => setSyncing(true);
+    const endHandler = () => setSyncing(false);
+    socket.on('syncStart', startHandler);
+    socket.on('syncEnd', endHandler);
+    return () => {
+      socket.off('syncStart', startHandler);
+      socket.off('syncEnd', endHandler);
+    };
+  }, []);
 
   useEffect(() => {
     localStorage.setItem('modeTactile', JSON.stringify(modeTactile));
@@ -105,6 +118,7 @@ function App() {
                 {devMode && (
                   <Nav.Link as={Link} to="/db-config" onClick={() => setShowMenu(false)}>⚙️ DB</Nav.Link>
                 )}
+                <Nav.Link as={Link} to="/parametres" onClick={() => setShowMenu(false)}>🛠️ Paramètres</Nav.Link>
               </Nav>
             </Offcanvas.Body>
           </Navbar.Offcanvas>
@@ -161,7 +175,7 @@ function App() {
                 }
               }}
             >
-              🔄
+              {syncing ? <span className="sync-spinner">🔄</span> : '🔄'}
             </button>
 
             <button
@@ -233,6 +247,7 @@ function App() {
             <Route path="/fermeture-caisse" element={<RequireSession><FermetureCaisse /></RequireSession>} />
             <Route path="/journal-caisse" element={<RequireSession><JournalCaisse /></RequireSession>} />
             <Route path="/compare-schemas" element={<RequireSession><CompareSchemas /></RequireSession>} />
+            <Route path="/parametres" element={<RequireSession><Parametres /></RequireSession>} />
             {devMode && (
               <Route path="/db-config" element={<RequireSession><DbConfig /></RequireSession>} />
             )}

--- a/frontend/src/pages/Parametres.jsx
+++ b/frontend/src/pages/Parametres.jsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import { Form, Button } from 'react-bootstrap';
+
+const Parametres = () => {
+  const [interval, setIntervalValue] = useState('');
+  const [enabled, setEnabled] = useState(true);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    fetch('http://localhost:3001/api/sync-config')
+      .then(res => res.json())
+      .then(data => {
+        setIntervalValue(String(data.interval));
+        setEnabled(data.enabled);
+      })
+      .catch(() => {});
+  }, []);
+
+  const save = async () => {
+    setMessage('');
+    try {
+      const res = await fetch('http://localhost:3001/api/sync-config', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ interval: parseInt(interval, 10), enabled })
+      });
+      const data = await res.json();
+      if (data.success) {
+        setMessage('Période sauvegardée');
+      } else {
+        setMessage(data.error || 'Erreur');
+      }
+    } catch {
+      setMessage('Erreur');
+    }
+  };
+
+  return (
+    <div className="container mt-3">
+      <h3>Paramètres</h3>
+      <Form>
+        <Form.Group className="mb-2">
+          <Form.Label>Période de synchronisation (minutes)</Form.Label>
+          <Form.Control
+            type="number"
+            value={interval}
+            onChange={e => setIntervalValue(e.target.value)}
+          />
+        </Form.Group>
+        <Form.Group className="form-check form-switch mb-2">
+          <Form.Check
+            type="switch"
+            id="syncEnabledSwitch"
+            label="Synchronisation automatique"
+            checked={enabled}
+            onChange={() => setEnabled(prev => !prev)}
+          />
+        </Form.Group>
+        <Button onClick={save}>Sauvegarder</Button>
+      </Form>
+      {message && <div className="mt-2">{message}</div>}
+    </div>
+  );
+};
+
+export default Parametres;

--- a/frontend/src/styles/App.scss
+++ b/frontend/src/styles/App.scss
@@ -49,5 +49,14 @@ html, body, #root {
   transition: max-height 0.3s ease-in-out;
 }
 
+.sync-spinner {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
 
 


### PR DESCRIPTION
## Summary
- add scheduler with enable flag and update config routes
- notify frontend of sync via WebSocket
- add sync toggle in settings page
- spin arrow when sync route is called automatically

## Testing
- `npm --prefix backend test` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_685042f5bb5083279f8d9009b2cde4da