### PR TITLE
Fix PDF paths for packaged Electron

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -3,6 +3,7 @@ const express = require('express');
 const cors = require('cors');
 const app = express();
 const path = require('path');
+const os = require('os');
 
 // Middlewares globaux
 app.use(cors());
@@ -55,7 +56,8 @@ app.use('/api/sync-config', syncConfigRoutes);
 app.use('/api/store-config', storeConfigRoutes);
 app.use('/api/boutons', boutonsRoutes);
 app.use('/api/categories', categoriesRoutes);
-app.use('/factures', express.static(path.join(__dirname, '../factures')));
+const baseDir = path.join(os.homedir(), '.bdd-caisse');
+app.use('/factures', express.static(path.join(baseDir, 'factures')));
 
 
 

--- a/backend/routes/facture.routes.js
+++ b/backend/routes/facture.routes.js
@@ -5,6 +5,7 @@ const { v4: uuidv4 } = require('uuid');
 const genererFacturePdf = require('../utils/genererFacturePdf');
 const path = require('path');
 const fs = require('fs');
+const os = require('os');
 const nodemailer = require('nodemailer');
 const logSync = require('../logsync');
 
@@ -52,7 +53,8 @@ router.post('/:uuid_ticket', async (req, res) => {
 
     // Envoi email si fourni
     if (email) {
-      const pdfPath = path.join(__dirname, '../../', lien);
+      const baseDir = path.join(os.homedir(), '.bdd-caisse');
+      const pdfPath = path.join(baseDir, lien);
       if (fs.existsSync(pdfPath)) {
         await transporter.sendMail({
           from: '"RessourceBrie" <magasin@ressourcebrie.fr>',

--- a/backend/routes/reset.routes.js
+++ b/backend/routes/reset.routes.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 const router = express.Router();
 const { sqlite, getMysqlPool } = require('../db');
 
@@ -53,7 +54,8 @@ router.post('/', async (req, res) => {
     }
 
     // 🧹 Suppression des fichiers de tickets
-    const ticketDir = path.join(__dirname, '../../tickets');
+    const baseDir = path.join(os.homedir(), '.bdd-caisse');
+    const ticketDir = path.join(baseDir, 'tickets');
     if (fs.existsSync(ticketDir)) {
       const fichiers = fs.readdirSync(ticketDir);
       fichiers.forEach(f => {

--- a/backend/utils/genererFacturePdf.js
+++ b/backend/utils/genererFacturePdf.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 const PDFDocument = require('pdfkit');
 const { sqlite } = require('../db');
 const { getFriendlyIdFromUuid } = require('../utils/genererFriendlyIds');
@@ -13,8 +14,9 @@ function genererFacturePdf(uuid_facture, uuid_ticket, raison_sociale, adresse) {
       if (!ticket) return reject(new Error('Ticket introuvable'));
 
       const articles = sqlite.prepare('SELECT * FROM objets_vendus WHERE uuid_ticket = ?').all(ticket.uuid_ticket);
-      const dir = path.join(__dirname, '../../factures');
-      if (!fs.existsSync(dir)) fs.mkdirSync(dir);
+      const baseDir = path.join(os.homedir(), '.bdd-caisse');
+      const dir = path.join(baseDir, 'factures');
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
       const pdfPath = path.join(dir, `Facture-${friendlyId}.pdf`);
 
       const doc = new PDFDocument({ size: 'A4', margin: 50 });

--- a/backend/utils/genererTicketCloturePdf.js
+++ b/backend/utils/genererTicketCloturePdf.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 const PDFDocument = require('pdfkit');
 const { sqlite } = require('../db');
 const axios = require('axios');
@@ -28,7 +29,8 @@ async function genererTicketCloturePdf(id_session) {
   const mm = String(date.getMonth() + 1).padStart(2, '0');
   const dd = String(date.getDate()).padStart(2, '0');
 
-  const dir = path.join(__dirname, `../../tickets/${yyyy}/${mm}/${dd}`);
+  const baseDir = path.join(os.homedir(), '.bdd-caisse');
+  const dir = path.join(baseDir, `tickets/${yyyy}/${mm}/${dd}`);
   fs.mkdirSync(dir, { recursive: true });
 
   const pdfPath = path.join(dir, `Cloture-${friendlyId}.pdf`);

--- a/backend/utils/genererTicketPdf.js
+++ b/backend/utils/genererTicketPdf.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 const PDFDocument = require('pdfkit');
 const { sqlite } = require('../db');
 const { getFriendlyIdFromUuid } = require('../utils/genererFriendlyIds');
@@ -19,7 +20,8 @@ function genererTicketPdf(uuid_ticket) {
       const mm = String(date.getMonth() + 1).padStart(2, '0');
       const dd = String(date.getDate()).padStart(2, '0');
 
-      const dir = path.join(__dirname, `../../tickets/${yyyy}/${mm}/${dd}`);
+      const baseDir = path.join(os.homedir(), '.bdd-caisse');
+      const dir = path.join(baseDir, `tickets/${yyyy}/${mm}/${dd}`);
       fs.mkdirSync(dir, { recursive: true }); // ✅ Crée tous les dossiers si besoin
 
       const pdfPath = path.join(dir, `Ticket-${friendlyId}.pdf`);
@@ -107,7 +109,7 @@ function genererTicketPdf(uuid_ticket) {
 
       stream.on('finish', () => {
   // 🧠 On extrait un chemin relatif propre pour l'enregistrement
-  const relativePath = path.relative(path.join(__dirname, '../../'), pdfPath).replace(/\\/g, '/');
+  const relativePath = path.relative(baseDir, pdfPath).replace(/\\/g, '/');
 
   // 📦 Mise à jour du champ `lien` en base
   sqlite.prepare('UPDATE ticketdecaisse SET lien = ? WHERE uuid_ticket = ?')

--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -3,6 +3,7 @@ const path = require('path');
 const fs = require('fs');
 const { spawn } = require('child_process');
 const http = require('http');
+const os = require('os');
 
 
 let mainWindow;
@@ -162,7 +163,8 @@ app.on('before-quit', (event) => {
 
 // 📂 Ouvre le PDF à la demande
 ipcMain.on('open-pdf', (event, relativePath) => {
-  const fullPath = path.resolve(__dirname, '..', relativePath);
+  const baseDir = path.join(os.homedir(), '.bdd-caisse');
+  const fullPath = path.join(baseDir, relativePath);
   if (fs.existsSync(fullPath)) {
     shell.openPath(fullPath);
   } else {


### PR DESCRIPTION
## Summary
- persist PDF files in user directory so packaged app can write to them
- update main process to open PDFs from that location

## Testing
- `npm test` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875361e48d48327b156cd9d7e2fd039