### PR TITLE
Fix paths for packaged environment

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -3,6 +3,8 @@ const express = require('express');
 const cors = require('cors');
 const app = express();
 const path = require('path');
+const os = require('os');
+const fs = require('fs');
 
 // Middlewares globaux
 app.use(cors());
@@ -55,7 +57,9 @@ app.use('/api/sync-config', syncConfigRoutes);
 app.use('/api/store-config', storeConfigRoutes);
 app.use('/api/boutons', boutonsRoutes);
 app.use('/api/categories', categoriesRoutes);
-app.use('/factures', express.static(path.join(__dirname, '../factures')));
+const baseDir = path.join(os.homedir(), '.bdd-caisse');
+fs.mkdirSync(baseDir, { recursive: true });
+app.use('/factures', express.static(path.join(baseDir, 'factures')));
 
 
 

--- a/backend/db.js
+++ b/backend/db.js
@@ -4,7 +4,10 @@ const Database = require('better-sqlite3');
 const mysql = require('mysql2/promise');
 require('dotenv').config({ path: path.join(__dirname, '.env') });
 
-const dbConfigPath = path.join(__dirname, 'dbConfig.json');
+const os = require('os');
+const baseDir = path.join(os.homedir(), '.bdd-caisse');
+const dbConfigPath = path.join(baseDir, 'dbConfig.json');
+fs.mkdirSync(baseDir, { recursive: true });
 
 function getMysqlPresets() {
   const presets = [];
@@ -65,7 +68,6 @@ function getMysqlPool() {
 // Connexion SQLite
 
 
-const os = require('os');
 const { app } = require('electron'); // uniquement si ce fichier est exécuté dans le main process Electron
 
 

--- a/backend/routes/dbconfig.routes.js
+++ b/backend/routes/dbconfig.routes.js
@@ -3,9 +3,11 @@ const router = express.Router();
 const { updateMysqlConfig, getMysqlPresets, getMysqlPool } = require('../db');
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 
-
-const configPath = path.join(__dirname, '../dbConfig.json');
+const baseDir = path.join(os.homedir(), '.bdd-caisse');
+const configPath = path.join(baseDir, 'dbConfig.json');
+fs.mkdirSync(baseDir, { recursive: true });
 
 router.get('/', (req, res) => {
   let conf;

--- a/backend/routes/reset.routes.js
+++ b/backend/routes/reset.routes.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 const router = express.Router();
 const { sqlite, getMysqlPool } = require('../db');
 
@@ -53,7 +54,8 @@ router.post('/', async (req, res) => {
     }
 
     // 🧹 Suppression des fichiers de tickets
-    const ticketDir = path.join(__dirname, '../../tickets');
+    const baseDir = path.join(os.homedir(), '.bdd-caisse');
+    const ticketDir = path.join(baseDir, 'tickets');
     if (fs.existsSync(ticketDir)) {
       const fichiers = fs.readdirSync(ticketDir);
       fichiers.forEach(f => {

--- a/backend/storeConfig.js
+++ b/backend/storeConfig.js
@@ -1,7 +1,10 @@
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 
-const configPath = path.join(__dirname, 'storeConfig.json');
+const baseDir = path.join(os.homedir(), '.bdd-caisse');
+const configPath = path.join(baseDir, 'storeConfig.json');
+fs.mkdirSync(baseDir, { recursive: true });
 
 function loadConfig() {
   if (fs.existsSync(configPath)) {

--- a/backend/syncScheduler.js
+++ b/backend/syncScheduler.js
@@ -1,9 +1,12 @@
 const path = require('path');
 const fs = require('fs');
+const os = require('os');
 const axios = require('axios');
 const cron = require('node-cron');
 
-const configPath = path.join(__dirname, 'syncConfig.json');
+const baseDir = path.join(os.homedir(), '.bdd-caisse');
+const configPath = path.join(baseDir, 'syncConfig.json');
+fs.mkdirSync(baseDir, { recursive: true });
 
 function loadConfig() {
   if (fs.existsSync(configPath)) {

--- a/backend/utils/genererFacturePdf.js
+++ b/backend/utils/genererFacturePdf.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 const PDFDocument = require('pdfkit');
 const { sqlite } = require('../db');
 const { getFriendlyIdFromUuid } = require('../utils/genererFriendlyIds');
@@ -20,7 +21,8 @@ function genererFacturePdf(uuid_facture, uuid_ticket, raison_sociale, adresse) {
       const yyyy = date.getFullYear();
       const mm = String(date.getMonth() + 1).padStart(2, '0');
       const dd = String(date.getDate()).padStart(2, '0');
-      const dir = path.join(__dirname, `../../factures/${yyyy}/${mm}/${dd}`);
+      const baseDir = path.join(os.homedir(), '.bdd-caisse');
+      const dir = path.join(baseDir, 'factures', yyyy, mm, dd);
       fs.mkdirSync(dir, { recursive: true });
 
       const pdfPath = path.join(dir, `Facture-${raison_sociale}-${friendlyId}.pdf`);
@@ -29,7 +31,11 @@ function genererFacturePdf(uuid_facture, uuid_ticket, raison_sociale, adresse) {
       const stream = fs.createWriteStream(pdfPath);
       doc.pipe(stream);
 
-      const logoPath = path.join(__dirname, '../../images/logo.png');
+      let logoPath = path.join(__dirname, '../../images/logo.png');
+      if (!fs.existsSync(logoPath) && process.resourcesPath) {
+        const alt = path.join(process.resourcesPath, 'images', 'logo.png');
+        if (fs.existsSync(alt)) logoPath = alt;
+      }
 
       // --- HEADER ---
       if (fs.existsSync(logoPath)) {

--- a/backend/utils/genererTicketCloturePdf.js
+++ b/backend/utils/genererTicketCloturePdf.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 const PDFDocument = require('pdfkit');
 const { sqlite } = require('../db');
 const axios = require('axios');
@@ -24,7 +25,8 @@ async function genererTicketCloturePdf(id_session, uuid_ticket) {
   const mm = String(date.getMonth() + 1).padStart(2, '0');
   const dd = String(date.getDate()).padStart(2, '0');
 
-  const dir = path.join(__dirname, `../../tickets/${yyyy}/${mm}/${dd}`);
+  const baseDir = path.join(os.homedir(), '.bdd-caisse');
+  const dir = path.join(baseDir, 'tickets', yyyy, mm, dd);
   fs.mkdirSync(dir, { recursive: true });
 
   const pdfPath = path.join(dir, `Cloture-${friendlyId}.pdf`);

--- a/backend/utils/genererTicketPdf.js
+++ b/backend/utils/genererTicketPdf.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 const PDFDocument = require('pdfkit');
 const { sqlite } = require('../db');
 const { getFriendlyIdFromUuid } = require('../utils/genererFriendlyIds');
@@ -19,7 +20,8 @@ function genererTicketPdf(uuid_ticket) {
       const mm = String(date.getMonth() + 1).padStart(2, '0');
       const dd = String(date.getDate()).padStart(2, '0');
 
-      const dir = path.join(__dirname, `../../tickets/${yyyy}/${mm}/${dd}`);
+      const baseDir = path.join(os.homedir(), '.bdd-caisse');
+      const dir = path.join(baseDir, 'tickets', yyyy, mm, dd);
       fs.mkdirSync(dir, { recursive: true }); // ✅ Crée tous les dossiers si besoin
 
       const pdfPath = path.join(dir, `Ticket-${friendlyId}.pdf`);
@@ -29,7 +31,11 @@ function genererTicketPdf(uuid_ticket) {
       const stream = fs.createWriteStream(pdfPath);
       doc.pipe(stream);
 
-      const logoPath = path.join(__dirname, '../../images/logo.png');
+      let logoPath = path.join(__dirname, '../../images/logo.png');
+      if (!fs.existsSync(logoPath) && process.resourcesPath) {
+        const alt = path.join(process.resourcesPath, 'images', 'logo.png');
+        if (fs.existsSync(alt)) logoPath = alt;
+      }
 
       // --- HEADER ---
       if (fs.existsSync(logoPath)) {


### PR DESCRIPTION
## Summary
- store generated PDFs in the user's home directory so the app can write files when packaged
- fallback to resourcesPath for logo image lookup
- store configuration files in the `.bdd-caisse` directory to avoid writing inside the ASAR

## Testing
- `npm install` *(fails: blocked)*
- `npm test` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_68753adccb188327bccf76896c3ca63a