### PR TITLE
feat: toggle payment layout

### DIFF
--- a/frontend/src/components/MainNavBar.jsx
+++ b/frontend/src/components/MainNavBar.jsx
@@ -4,6 +4,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { DevModeContext } from '../contexts/DevModeContext';
 import { useActiveSession } from '../contexts/SessionCaisseContext';
 import { useSession } from '../contexts/SessionContext';
+import { ModePaiementBoutonsContext } from '../contexts/ModePaiementBoutonsContext';
 import { toast } from 'react-toastify';
 import { io } from 'socket.io-client';
 const socket = io('http://localhost:3001');
@@ -15,6 +16,7 @@ function MainNavbar() {
   const { user } = useSession();
   const [syncStatus, setSyncStatus] = useState(null);
   const navigate = useNavigate();
+  const { modePaiementBoutons, setModePaiementBoutons } = useContext(ModePaiementBoutonsContext);
 
   useEffect(() => {
     const startHandler = () => {
@@ -87,6 +89,19 @@ function MainNavbar() {
           </div>
 
           <div className="d-flex align-items-center ms-auto">
+
+            <div className="form-check form-switch text-white me-2">
+              <input
+                className="form-check-input"
+                type="checkbox"
+                id="modePaiementBoutonsSwitch"
+                checked={modePaiementBoutons}
+                onChange={() => setModePaiementBoutons(prev => !prev)}
+              />
+              <label className="form-check-label" htmlFor="modePaiementBoutonsSwitch">
+                💳
+              </label>
+            </div>
 
             <button
   className="btn btn-sm btn-outline-success me-2"

--- a/frontend/src/contexts/ModePaiementBoutonsContext.js
+++ b/frontend/src/contexts/ModePaiementBoutonsContext.js
@@ -1,0 +1,23 @@
+import React, { createContext, useEffect, useState } from 'react';
+
+export const ModePaiementBoutonsContext = createContext();
+
+export const ModePaiementBoutonsProvider = ({ children }) => {
+  const [modePaiementBoutons, setModePaiementBoutons] = useState(() => {
+    const saved = localStorage.getItem('modePaiementBoutons');
+    return saved ? JSON.parse(saved) : false;
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('modePaiementBoutons', JSON.stringify(modePaiementBoutons));
+    } catch {}
+  }, [modePaiementBoutons]);
+
+  return (
+    <ModePaiementBoutonsContext.Provider value={{ modePaiementBoutons, setModePaiementBoutons }}>
+      {children}
+    </ModePaiementBoutonsContext.Provider>
+  );
+};
+

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -7,21 +7,24 @@ import { SessionProvider } from './contexts/SessionContext';
 import { SessionCaisseProvider } from './contexts/SessionCaisseContext';
 import { SessionCaisseSecondaireProvider } from './contexts/SessionCaisseContext';
 import { ModeTactileProvider } from './contexts/ModeTactileContext';
+import { ModePaiementBoutonsProvider } from './contexts/ModePaiementBoutonsContext';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <HashRouter>
-    <ModeTactileProvider>
-      <DevModeProvider>
-        <SessionProvider>
-          <SessionCaisseProvider>
-            <SessionCaisseSecondaireProvider>
-              <App />
-            </SessionCaisseSecondaireProvider>
-          </SessionCaisseProvider>
-        </SessionProvider>
-      </DevModeProvider>
-    </ModeTactileProvider>
+    <ModePaiementBoutonsProvider>
+      <ModeTactileProvider>
+        <DevModeProvider>
+          <SessionProvider>
+            <SessionCaisseProvider>
+              <SessionCaisseSecondaireProvider>
+                <App />
+              </SessionCaisseSecondaireProvider>
+            </SessionCaisseProvider>
+          </SessionProvider>
+        </DevModeProvider>
+      </ModeTactileProvider>
+    </ModePaiementBoutonsProvider>
   </HashRouter>
 );
 


### PR DESCRIPTION
## Summary
- add context and toggle to switch validation layout
- support direct payment buttons with mixte modal

## Testing
- `CI=true npm test` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68c0178906908327b09f1c3be36402cd