### PR TITLE
Move touch mode toggle to main navbar

### DIFF
--- a/frontend/src/components/MainNavBar.jsx
+++ b/frontend/src/components/MainNavBar.jsx
@@ -5,6 +5,7 @@ import { DevModeContext } from '../contexts/DevModeContext';
 import { useActiveSession } from '../contexts/SessionCaisseContext';
 import { useSession } from '../contexts/SessionContext';
 import { ModePaiementBoutonsContext } from '../contexts/ModePaiementBoutonsContext';
+import ModeTactileToggle from './ModeTactileToggle';
 import { toast } from 'react-toastify';
 import { io } from 'socket.io-client';
 const socket = io('http://localhost:3001');
@@ -89,7 +90,7 @@ function MainNavbar() {
           </div>
 
           <div className="d-flex align-items-center ms-auto">
-
+            <ModeTactileToggle />
             <div className="form-check form-switch text-white me-2">
               <input
                 className="form-check-input"

--- a/frontend/src/components/ModeTactileToggle.jsx
+++ b/frontend/src/components/ModeTactileToggle.jsx
@@ -5,7 +5,7 @@ const ModeTactileToggle = () => {
   const { modeTactile, setModeTactile } = useContext(ModeTactileContext);
 
   return (
-    <div className="form-check form-switch ms-2">
+    <div className="form-check form-switch text-white me-2">
       <input
         className="form-check-input"
         type="checkbox"
@@ -14,7 +14,7 @@ const ModeTactileToggle = () => {
         checked={modeTactile}
         onChange={() => setModeTactile(prev => !prev)}
       />
-      <label className="form-check-label text-white" htmlFor="modeTactileSwitch">
+      <label className="form-check-label" htmlFor="modeTactileSwitch">
         🖐️
       </label>
     </div>

--- a/frontend/src/pages/Parametres.jsx
+++ b/frontend/src/pages/Parametres.jsx
@@ -3,7 +3,6 @@ import { Form, Button, Collapse } from 'react-bootstrap';
 import BoutonsManager from '../components/BoutonsManager';
 import ResetButton from '../components/ResetButton';
 import DevModeToggle from '../components/DevModeToggle';
-import ModeTactileToggle from '../components/ModeTactileToggle';
 import DevModeModal from '../components/DevModeModal';
 import { useContext } from 'react';
 import { DevModeContext } from '../contexts/DevModeContext';
@@ -225,14 +224,6 @@ const [showBoutons, setShowBoutons] = useState(false);
             <BoutonsManager />
           </div>
         </Collapse>
-
-        <hr />
-
-        <h4>🖐️ Options d'affichage</h4>
-        <p>Activer le mode tactile</p>
-        <div className="d-flex gap-3 mb-3">
-          <ModeTactileToggle />
-        </div>
 
         <hr />
 


### PR DESCRIPTION
## Summary
- Relocate touch mode toggle from settings page to main navigation bar
- Style ModeTactileToggle for navbar usage

## Testing
- `cd frontend && npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68c041bb48c88327a3a59024c07e2d31