### PR TITLE
feat: add user sync module

### DIFF
--- a/backend/routes/users.routes.js
+++ b/backend/routes/users.routes.js
@@ -1,7 +1,7 @@
 
 const express = require('express');
 const router = express.Router();
-const { sqlite } = require('../db');
+const { sqlite, getMysqlPool } = require('../db');
 const bcrypt = require('bcrypt');
 const logSync = require('../logsync');
 
@@ -48,6 +48,69 @@ router.post('/', (req, res) => {
   });
 
   res.json({ success: true });
+});
+
+// GET /api/users/compare — compare MySQL vs SQLite
+router.get('/compare', async (req, res) => {
+  try {
+    const pool = getMysqlPool();
+    const [mysqlUsers] = await pool.query(
+      'SELECT uuid_user, prenom, nom, pseudo, password, admin, mail, tel FROM users'
+    );
+    const sqliteUsers = sqlite
+      .prepare('SELECT uuid_user, prenom, nom, pseudo, password, admin, mail, tel FROM users')
+      .all();
+    const localMap = new Map(sqliteUsers.map(u => [u.uuid_user, u]));
+    const remoteMap = new Map(mysqlUsers.map(u => [u.uuid_user, u]));
+
+    const missing = mysqlUsers.filter(u => !localMap.has(u.uuid_user));
+    const extra = sqliteUsers.filter(u => !remoteMap.has(u.uuid_user));
+    const different = mysqlUsers.filter(u => {
+      const lu = localMap.get(u.uuid_user);
+      if (!lu) return false;
+      return ['prenom', 'nom', 'pseudo', 'password', 'admin', 'mail', 'tel'].some(
+        f => String(u[f] ?? '') !== String(lu[f] ?? '')
+      );
+    });
+
+    res.json({ success: true, missing, extra, different });
+  } catch (err) {
+    console.error('Erreur comparaison users:', err);
+    res.status(500).json({ success: false, error: 'Erreur comparaison users' });
+  }
+});
+
+// POST /api/users/sync — replace local table with remote data
+router.post('/sync', async (req, res) => {
+  try {
+    const pool = getMysqlPool();
+    const [mysqlUsers] = await pool.query(
+      'SELECT uuid_user, prenom, nom, pseudo, password, admin, mail, tel FROM users'
+    );
+    const insert = sqlite.prepare(
+      'INSERT OR REPLACE INTO users (uuid_user, prenom, nom, pseudo, password, admin, mail, tel) VALUES (?,?,?,?,?,?,?,?)'
+    );
+    const replaceAll = sqlite.transaction(users => {
+      sqlite.prepare('DELETE FROM users').run();
+      for (const u of users) {
+        insert.run(
+          u.uuid_user,
+          u.prenom,
+          u.nom,
+          u.pseudo,
+          u.password,
+          u.admin,
+          u.mail || '',
+          u.tel || ''
+        );
+      }
+    });
+    replaceAll(mysqlUsers);
+    res.json({ success: true, count: mysqlUsers.length });
+  } catch (err) {
+    console.error('Erreur sync users:', err);
+    res.status(500).json({ success: false, error: 'Erreur mise à jour users' });
+  }
 });
 
 module.exports = router;

--- a/frontend/src/pages/Parametres.jsx
+++ b/frontend/src/pages/Parametres.jsx
@@ -24,6 +24,10 @@ const [showBoutons, setShowBoutons] = useState(false);
   const [scanned, setScanned] = useState(false);
   const [scanMessage, setScanMessage] = useState('');
 
+  const [usersDiff, setUsersDiff] = useState(null);
+  const [usersMsg, setUsersMsg] = useState('');
+  const [usersError, setUsersError] = useState('');
+
   const [showPassModal, setShowPassModal] = useState(false);
   const { devMode, setDevMode } = useContext(DevModeContext);
 
@@ -127,6 +131,43 @@ const [showBoutons, setShowBoutons] = useState(false);
     }
   };
 
+  const compareUsers = async () => {
+    setUsersError('');
+    setUsersMsg('');
+    try {
+      const res = await fetch('http://localhost:3001/api/users/compare');
+      const data = await res.json();
+      if (data.success) {
+        setUsersDiff({
+          missing: data.missing.length,
+          extra: data.extra.length,
+          different: data.different.length
+        });
+      } else {
+        setUsersError(data.error || 'Erreur');
+      }
+    } catch {
+      setUsersError('Erreur lors de la comparaison');
+    }
+  };
+
+  const syncUsers = async () => {
+    setUsersError('');
+    setUsersMsg('');
+    try {
+      const res = await fetch('http://localhost:3001/api/users/sync', { method: 'POST' });
+      const data = await res.json();
+      if (data.success) {
+        setUsersMsg(`Mise à jour effectuée (${data.count} utilisateurs).`);
+        setUsersDiff(null);
+      } else {
+        setUsersError(data.error || 'Erreur');
+      }
+    } catch {
+      setUsersError('Erreur lors de la mise à jour');
+    }
+  };
+
   useEffect(() => {
   console.log('🧪 window.electron:', window.electron);
 }, []);
@@ -204,6 +245,23 @@ const [showBoutons, setShowBoutons] = useState(false);
               ))}
             </ul>
           )}
+        </div>
+
+        <hr />
+
+        <h3>👥 Synchronisation utilisateurs</h3>
+        <div className="mb-3">
+          <Button onClick={compareUsers} className="me-2">Comparer</Button>
+          {usersDiff && (
+            <div className="mt-2">
+              <p>À ajouter: {usersDiff.missing} – À supprimer: {usersDiff.extra} – Différents: {usersDiff.different}</p>
+              <Button variant="secondary" onClick={syncUsers} className="mt-2">
+                Mettre à jour la base locale
+              </Button>
+            </div>
+          )}
+          {usersError && <div className="mt-2 text-danger">{usersError}</div>}
+          {usersMsg && <div className="mt-2">{usersMsg}</div>}
         </div>
 
         <hr />


### PR DESCRIPTION
## Summary
- compare MySQL and SQLite user tables
- allow updating local users from remote via settings page

## Testing
- `cd backend && npm test` *(fails: Cannot find module '../logsync')*

------
https://chatgpt.com/codex/tasks/task_e_68c0745eccc883279975eb1b17924a62