### PR TITLE
Add automated SFTP sync for ticket PDFs

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -66,6 +66,7 @@ const principalIpRoutes = require('./routes/principalIp.routes');
 const networkRoutes = require('./routes/network.routes');
 const friendlyRoutes = require('./routes/friendly.routes');
 const motifsRoutes = require('./routes/motifs.routes');
+const ticketSyncRoutes = require('./routes/ticketSync.routes');
 
 
 
@@ -101,6 +102,7 @@ app.use('/api/categories', categoriesRoutes);
 app.use('/api/motifs', motifsRoutes);
 app.use('/api/sync/envoyer-secondaire-vers-principal', envoyerSecondaireVersPrincipal);
 app.use('/api/friendly', friendlyRoutes);
+app.use('/api/ticket-sync', ticketSyncRoutes);
 
 fs.mkdirSync(baseDir, { recursive: true });
 app.use('/factures', express.static(path.join(baseDir, 'factures')));

--- a/backend/index.js
+++ b/backend/index.js
@@ -3,6 +3,7 @@ const http = require('http');
 const app = require('./app');
 const PORT = process.env.PORT || 3001;
 const { startScheduler } = require('./syncScheduler');
+const { startTicketSyncScheduler } = require('./ticketSyncScheduler');
 
 const server = http.createServer(app);
 const io = require('socket.io')(server, {
@@ -21,6 +22,7 @@ app.use('/api/sync/recevoir-de-secondaire', recevoirDeSecondaire);
 server.listen(PORT, () => {
   console.log(`Serveur backend lancé sur http://localhost:${PORT}`);
   startScheduler(PORT, io);
+  startTicketSyncScheduler();
 });
 
 /* // Émet une fausse synchronisation toutes les 15 secondes

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,7 @@
     "nodemailer": "^7.0.3",
     "pdfkit": "^0.17.1",
     "socket.io": "^4.8.1",
+    "ssh2-sftp-client": "^10.0.3",
     "uuid": "^11.1.0"
     
   },

--- a/backend/routes/ticketSync.routes.js
+++ b/backend/routes/ticketSync.routes.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const router = express.Router();
+const {
+  refreshTicketSyncConfig,
+  getTicketSyncConfig,
+  triggerTicketSync,
+  getTicketSyncStatus
+} = require('../ticketSyncScheduler');
+
+router.get('/config', (req, res) => {
+  res.json(getTicketSyncConfig());
+});
+
+router.post('/config', (req, res) => {
+  try {
+    const { interval, enabled, host, port, username, password, remoteBasePath } = req.body || {};
+    const config = refreshTicketSyncConfig({ interval, enabled, host, port, username, password, remoteBasePath });
+    res.json({ success: true, config });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message || 'Erreur sauvegarde configuration' });
+  }
+});
+
+router.post('/run', (req, res) => {
+  const result = triggerTicketSync({ force: true, source: 'manual' });
+  if (result.started) {
+    return res.status(202).json({ success: true, started: true });
+  }
+  if (result.reason === 'running') {
+    return res.status(409).json({ success: false, error: 'Synchronisation déjà en cours.' });
+  }
+  res.status(400).json({ success: false, error: result.reason || 'Impossible de démarrer la synchronisation.' });
+});
+
+router.get('/status', (req, res) => {
+  res.json(getTicketSyncStatus());
+});
+
+module.exports = router;

--- a/backend/ticketSyncConfig.js
+++ b/backend/ticketSyncConfig.js
@@ -1,0 +1,76 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const baseDir = path.join(os.homedir(), '.bdd-caisse');
+const configPath = path.join(baseDir, 'ticketSyncConfig.json');
+
+const defaultConfig = {
+  enabled: true,
+  interval: 30,
+  host: '',
+  port: 22,
+  username: '',
+  password: '',
+  remoteBasePath: '/tickets'
+};
+
+function ensureBaseDir() {
+  fs.mkdirSync(baseDir, { recursive: true });
+}
+
+function loadConfig() {
+  ensureBaseDir();
+  if (fs.existsSync(configPath)) {
+    try {
+      const raw = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      return { ...defaultConfig, ...raw };
+    } catch (err) {
+      console.error('Impossible de lire ticketSyncConfig.json, utilisation des valeurs par défaut.', err);
+    }
+  }
+  return { ...defaultConfig };
+}
+
+let cachedConfig = loadConfig();
+
+function getTicketSyncConfig() {
+  return { ...cachedConfig };
+}
+
+function updateTicketSyncConfig(patch) {
+  const next = { ...cachedConfig };
+
+  if (patch) {
+    if (typeof patch.enabled === 'boolean') next.enabled = patch.enabled;
+
+    if (typeof patch.interval === 'number' && Number.isFinite(patch.interval) && patch.interval > 0) {
+      next.interval = Math.round(patch.interval);
+    }
+
+    if (typeof patch.host === 'string') next.host = patch.host.trim();
+    if (typeof patch.username === 'string') next.username = patch.username.trim();
+    if (typeof patch.password === 'string') next.password = patch.password;
+    if (typeof patch.remoteBasePath === 'string' && patch.remoteBasePath.trim() !== '') {
+      next.remoteBasePath = patch.remoteBasePath.trim();
+    }
+
+    if (patch.port !== undefined) {
+      const port = Number(patch.port);
+      if (Number.isFinite(port) && port > 0) {
+        next.port = Math.round(port);
+      }
+    }
+  }
+
+  cachedConfig = next;
+  ensureBaseDir();
+  fs.writeFileSync(configPath, JSON.stringify(cachedConfig, null, 2));
+  return getTicketSyncConfig();
+}
+
+module.exports = {
+  getTicketSyncConfig,
+  updateTicketSyncConfig,
+  configPath
+};

--- a/backend/ticketSyncScheduler.js
+++ b/backend/ticketSyncScheduler.js
@@ -1,0 +1,42 @@
+const cron = require('node-cron');
+const { triggerTicketSync, getTicketSyncStatus } = require('./ticketSyncService');
+const { getTicketSyncConfig, updateTicketSyncConfig } = require('./ticketSyncConfig');
+
+let job = null;
+
+function schedule() {
+  if (job) {
+    job.stop();
+    job = null;
+  }
+  const { interval, enabled } = getTicketSyncConfig();
+  if (!enabled) return;
+
+  const safeInterval = Math.max(1, Math.round(interval || 1));
+  job = cron.schedule(`*/${safeInterval} * * * *`, () => {
+    const res = triggerTicketSync({ source: 'auto' });
+    if (!res.started && res.reason !== 'disabled') {
+      if (res.reason !== 'running') {
+        console.warn('Synchronisation tickets non démarrée :', res.reason);
+      }
+    }
+  });
+}
+
+function startTicketSyncScheduler() {
+  schedule();
+}
+
+function refreshTicketSyncConfig(patch) {
+  const config = updateTicketSyncConfig(patch);
+  schedule();
+  return config;
+}
+
+module.exports = {
+  startTicketSyncScheduler,
+  refreshTicketSyncConfig,
+  getTicketSyncConfig,
+  triggerTicketSync,
+  getTicketSyncStatus
+};

--- a/backend/ticketSyncService.js
+++ b/backend/ticketSyncService.js
@@ -1,0 +1,180 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const SftpClient = require('ssh2-sftp-client');
+const { getTicketSyncConfig } = require('./ticketSyncConfig');
+
+const localTicketsBaseDir = path.join(os.homedir(), '.bdd-caisse', 'tickets');
+
+let isRunning = false;
+let lastRunAt = null;
+let lastResult = null;
+let lastError = null;
+
+function toPosix(p) {
+  return p.split(path.sep).join('/');
+}
+
+function collectLocalFiles(dir) {
+  const results = [];
+  if (!fs.existsSync(dir)) {
+    return results;
+  }
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectLocalFiles(fullPath));
+    } else if (entry.isFile()) {
+      const stat = fs.statSync(fullPath);
+      results.push({
+        path: fullPath,
+        size: stat.size,
+        mtimeMs: stat.mtimeMs
+      });
+    }
+  }
+  return results;
+}
+
+async function ensureRemoteDir(sftp, dir, cache) {
+  const normalized = dir.endsWith('/') ? dir.slice(0, -1) : dir;
+  if (cache.has(normalized)) return;
+  try {
+    await sftp.mkdir(normalized, true);
+  } catch (err) {
+    if (err.code !== 4 && err.code !== 11 && err.message?.includes('Failure') === false) {
+      throw err;
+    }
+  }
+  cache.add(normalized);
+}
+
+async function uploadFile(sftp, localFile, remoteBase, cache) {
+  const relative = path.relative(localTicketsBaseDir, localFile.path);
+  const remotePath = toPosix(path.posix.join(remoteBase, toPosix(relative)));
+  const remoteDir = path.posix.dirname(remotePath);
+
+  await ensureRemoteDir(sftp, remoteDir, cache);
+
+  let skip = false;
+  try {
+    const stat = await sftp.stat(remotePath);
+    if (stat && stat.size === localFile.size) {
+      skip = true;
+    }
+  } catch (err) {
+    if (err.code !== 2 && !/No such file/i.test(err.message || '')) {
+      throw err;
+    }
+  }
+
+  if (skip) {
+    return { skipped: true, remotePath };
+  }
+
+  await sftp.fastPut(localFile.path, remotePath);
+  return { skipped: false, remotePath };
+}
+
+async function runSyncJob({ source = 'manual' } = {}) {
+  const config = getTicketSyncConfig();
+  const summary = {
+    source,
+    uploaded: 0,
+    skipped: 0,
+    total: 0
+  };
+
+  if (!fs.existsSync(localTicketsBaseDir)) {
+    return summary;
+  }
+
+  const files = collectLocalFiles(localTicketsBaseDir);
+  summary.total = files.length;
+
+  if (files.length === 0) {
+    return summary;
+  }
+
+  if (!config.host || !config.username || !config.remoteBasePath) {
+    throw new Error('Configuration SFTP incomplète (hôte, utilisateur ou chemin distant manquant).');
+  }
+
+  const sftp = new SftpClient();
+  const createdDirs = new Set();
+  try {
+    await sftp.connect({
+      host: config.host,
+      port: config.port || 22,
+      username: config.username,
+      password: config.password || undefined
+    });
+
+    const remoteBaseRaw = config.remoteBasePath.replace(/\\/g, '/');
+    const remoteBase = remoteBaseRaw === '/' ? '/' : remoteBaseRaw.replace(/\/$/, '');
+
+    for (const file of files) {
+      try {
+        const result = await uploadFile(sftp, file, remoteBase, createdDirs);
+        if (result.skipped) summary.skipped += 1;
+        else summary.uploaded += 1;
+      } catch (err) {
+        if (!summary.errors) summary.errors = [];
+        summary.errors.push({ file: file.path, message: err.message });
+      }
+    }
+  } finally {
+    try {
+      await sftp.end();
+    } catch {}
+  }
+
+  return summary;
+}
+
+function triggerTicketSync({ force = false, source = 'manual' } = {}) {
+  const config = getTicketSyncConfig();
+  if (!force && !config.enabled) {
+    return { started: false, reason: 'disabled' };
+  }
+
+  if (isRunning) {
+    return { started: false, reason: 'running' };
+  }
+
+  isRunning = true;
+  lastError = null;
+
+  setImmediate(async () => {
+    try {
+      const summary = await runSyncJob({ source });
+      lastResult = summary;
+    } catch (err) {
+      lastError = err.message || String(err);
+      lastResult = null;
+      console.error('Erreur de synchronisation des tickets :', err);
+    } finally {
+      lastRunAt = new Date().toISOString();
+      isRunning = false;
+    }
+  });
+
+  return { started: true };
+}
+
+function getTicketSyncStatus() {
+  return {
+    running: isRunning,
+    lastRunAt,
+    lastResult,
+    lastError
+  };
+}
+
+module.exports = {
+  triggerTicketSync,
+  getTicketSyncStatus,
+  runSyncJob
+};


### PR DESCRIPTION
## Summary
- add an SFTP-based service to upload generated ticket PDFs while keeping local copies and scheduling automatic runs
- expose configuration, status and manual trigger endpoints plus register the scheduler and dependency in the backend
- extend the parameters screen with SFTP settings, manual trigger controls and status feedback for ticket transfers

## Testing
- not run (ssh2-sftp-client package is unavailable in the execution environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68e7bfd0a4e88327a5abafbe675257a6)