### PR TITLE
Add WebDAV ticket synchronization

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -66,6 +66,7 @@ const principalIpRoutes = require('./routes/principalIp.routes');
 const networkRoutes = require('./routes/network.routes');
 const friendlyRoutes = require('./routes/friendly.routes');
 const motifsRoutes = require('./routes/motifs.routes');
+const webdavRoutes = require('./routes/webdav.routes');
 
 
 
@@ -101,6 +102,7 @@ app.use('/api/categories', categoriesRoutes);
 app.use('/api/motifs', motifsRoutes);
 app.use('/api/sync/envoyer-secondaire-vers-principal', envoyerSecondaireVersPrincipal);
 app.use('/api/friendly', friendlyRoutes);
+app.use('/api/webdav', webdavRoutes);
 
 fs.mkdirSync(baseDir, { recursive: true });
 app.use('/factures', express.static(path.join(baseDir, 'factures')));

--- a/backend/index.js
+++ b/backend/index.js
@@ -3,6 +3,7 @@ const http = require('http');
 const app = require('./app');
 const PORT = process.env.PORT || 3001;
 const { startScheduler } = require('./syncScheduler');
+const { startWebdavScheduler } = require('./webdavScheduler');
 
 const server = http.createServer(app);
 const io = require('socket.io')(server, {
@@ -21,6 +22,7 @@ app.use('/api/sync/recevoir-de-secondaire', recevoirDeSecondaire);
 server.listen(PORT, () => {
   console.log(`Serveur backend lancé sur http://localhost:${PORT}`);
   startScheduler(PORT, io);
+  startWebdavScheduler();
 });
 
 /* // Émet une fausse synchronisation toutes les 15 secondes

--- a/backend/routes/webdav.routes.js
+++ b/backend/routes/webdav.routes.js
@@ -1,0 +1,42 @@
+const express = require('express');
+const router = express.Router();
+const {
+  updateWebdavSchedulerConfig,
+  getWebdavSchedulerConfig,
+  runSync,
+  getWebdavState
+} = require('../webdavScheduler');
+const { getAvailableModes } = require('../webdavConfig');
+
+router.get('/config', (req, res) => {
+  res.json(getWebdavSchedulerConfig());
+});
+
+router.post('/config', (req, res) => {
+  const { interval, enabled, mode } = req.body || {};
+  const parsedInterval = Number(interval);
+  if (!parsedInterval || parsedInterval <= 0) {
+    return res.status(400).json({ error: 'Interval invalide' });
+  }
+  const modes = getAvailableModes();
+  if (mode && !modes.find(m => m.key === mode)) {
+    return res.status(400).json({ error: 'Mode WebDAV inconnu' });
+  }
+  updateWebdavSchedulerConfig({ interval: parsedInterval, enabled: typeof enabled === 'boolean' ? enabled : undefined, mode });
+  res.json({ success: true });
+});
+
+router.post('/sync', async (req, res) => {
+  try {
+    const result = await runSync();
+    res.json({ success: true, count: result ? result.count : 0 });
+  } catch (error) {
+    res.status(500).json({ error: error.message || 'Erreur lors de la synchronisation WebDAV' });
+  }
+});
+
+router.get('/state', (req, res) => {
+  res.json(getWebdavState() || {});
+});
+
+module.exports = router;

--- a/backend/webdavConfig.js
+++ b/backend/webdavConfig.js
@@ -1,0 +1,99 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const baseDir = path.join(os.homedir(), '.bdd-caisse');
+const configPath = path.join(baseDir, 'webdavSyncConfig.json');
+fs.mkdirSync(baseDir, { recursive: true });
+
+function loadEnvTargets() {
+  const raw = process.env.WEBDAV_ENDPOINTS || process.env.WEBDAV_CONFIG;
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null) return {};
+    const normalized = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (!value || typeof value !== 'object') continue;
+      const { url, username, password, basePath, label } = value;
+      if (!url || !username || !password) continue;
+      normalized[key] = {
+        url,
+        username,
+        password,
+        basePath: basePath || '/tickets',
+        label: label || key
+      };
+    }
+    return normalized;
+  } catch {
+    return {};
+  }
+}
+
+function loadPersistedConfig(defaultMode) {
+  if (fs.existsSync(configPath)) {
+    try {
+      const data = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      return {
+        enabled: typeof data.enabled === 'boolean' ? data.enabled : false,
+        interval: typeof data.interval === 'number' && data.interval > 0 ? data.interval : 60,
+        mode: typeof data.mode === 'string' ? data.mode : defaultMode
+      };
+    } catch {}
+  }
+  return { enabled: false, interval: 60, mode: defaultMode };
+}
+
+const envTargets = loadEnvTargets();
+let { enabled, interval, mode } = loadPersistedConfig(Object.keys(envTargets)[0] || null);
+
+function persist() {
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify({ enabled, interval, mode }, null, 2)
+  );
+}
+
+function getAvailableModes() {
+  const targets = loadEnvTargets();
+  return Object.entries(targets).map(([key, value]) => ({
+    key,
+    label: value.label || key,
+    url: value.url,
+    basePath: value.basePath || '/tickets'
+  }));
+}
+
+function updateWebdavConfig(newInterval, newEnabled, newMode) {
+  if (typeof newInterval === 'number' && newInterval > 0) interval = newInterval;
+  if (typeof newEnabled === 'boolean') enabled = newEnabled;
+  if (typeof newMode === 'string' && loadEnvTargets()[newMode]) mode = newMode;
+  persist();
+}
+
+function getWebdavConfig() {
+  const targets = loadEnvTargets();
+  if (!mode || !targets[mode]) {
+    mode = Object.keys(targets)[0] || null;
+  }
+  return {
+    enabled,
+    interval,
+    mode,
+    availableModes: getAvailableModes()
+  };
+}
+
+function getActiveCredentials() {
+  const targets = loadEnvTargets();
+  if (!mode || !targets[mode]) return null;
+  return targets[mode];
+}
+
+module.exports = {
+  getWebdavConfig,
+  updateWebdavConfig,
+  getActiveCredentials,
+  getAvailableModes
+};

--- a/backend/webdavScheduler.js
+++ b/backend/webdavScheduler.js
@@ -1,0 +1,80 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const cron = require('node-cron');
+const { uploadTickets } = require('./webdavSync');
+const { getWebdavConfig, updateWebdavConfig, getActiveCredentials } = require('./webdavConfig');
+
+const baseDir = path.join(os.homedir(), '.bdd-caisse');
+const statePath = path.join(baseDir, 'webdavSyncState.json');
+fs.mkdirSync(baseDir, { recursive: true });
+
+let job = null;
+let isRunning = false;
+
+function saveState(payload) {
+  try {
+    fs.writeFileSync(statePath, JSON.stringify(payload, null, 2));
+  } catch {
+    // ignore write errors
+  }
+}
+
+async function runSync() {
+  if (isRunning) return null;
+  isRunning = true;
+  const start = new Date();
+  try {
+    const count = await uploadTickets();
+    const end = new Date();
+    saveState({ lastRun: start.toISOString(), lastDurationMs: end - start, lastResult: 'success', lastCount: count });
+    return { success: true, count };
+  } catch (error) {
+    saveState({ lastRun: start.toISOString(), lastResult: 'error', error: error.message });
+    throw error;
+  } finally {
+    isRunning = false;
+  }
+}
+
+function scheduleJob() {
+  const { enabled, interval } = getWebdavConfig();
+  if (job) job.stop();
+  if (!enabled) return;
+  if (!getActiveCredentials()) return;
+  job = cron.schedule(`*/${interval} * * * *`, () => {
+    runSync().catch(() => {});
+  });
+}
+
+function startWebdavScheduler() {
+  scheduleJob();
+}
+
+function updateWebdavSchedulerConfig({ interval, enabled, mode }) {
+  updateWebdavConfig(interval, enabled, mode);
+  scheduleJob();
+}
+
+function getWebdavSchedulerConfig() {
+  return getWebdavConfig();
+}
+
+function getWebdavState() {
+  if (fs.existsSync(statePath)) {
+    try {
+      return JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+module.exports = {
+  startWebdavScheduler,
+  updateWebdavSchedulerConfig,
+  getWebdavSchedulerConfig,
+  runSync,
+  getWebdavState
+};

--- a/backend/webdavSync.js
+++ b/backend/webdavSync.js
@@ -1,0 +1,90 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const axios = require('axios');
+const { getActiveCredentials } = require('./webdavConfig');
+
+const baseDir = path.join(os.homedir(), '.bdd-caisse');
+const ticketsDir = path.join(baseDir, 'tickets');
+
+async function listLocalFiles(rootDir) {
+  const results = [];
+  async function walk(current, prefix = '') {
+    const entries = await fs.promises.readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const absPath = path.join(current, entry.name);
+      const relPath = path.join(prefix, entry.name);
+      if (entry.isDirectory()) {
+        await walk(absPath, relPath);
+      } else if (entry.isFile()) {
+        results.push({ absPath, relPath });
+      }
+    }
+  }
+
+  if (fs.existsSync(rootDir)) {
+    await walk(rootDir);
+  }
+
+  return results;
+}
+
+function buildAuthHeader(username, password) {
+  const token = Buffer.from(`${username}:${password}`).toString('base64');
+  return { Authorization: `Basic ${token}` };
+}
+
+function normalizeRemotePath(basePathValue, relativePath) {
+  const normalizedBase = basePathValue.startsWith('/') ? basePathValue : `/${basePathValue}`;
+  return path.posix.join(normalizedBase, relativePath.split(path.sep).join('/'));
+}
+
+function buildRemoteUrl(baseUrl, remotePath) {
+  const sanitizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+  const cleanPath = remotePath.startsWith('/') ? remotePath.slice(1) : remotePath;
+  return new URL(cleanPath, sanitizedBase).toString();
+}
+
+async function ensureRemoteDir(baseUrl, headers, remotePath) {
+  if (!remotePath || remotePath === '/') return;
+  const segments = remotePath.split('/').filter(Boolean);
+  let current = '';
+  for (const segment of segments) {
+    current += `/${segment}`;
+    const targetUrl = buildRemoteUrl(baseUrl, current);
+    await axios({
+      method: 'MKCOL',
+      url: targetUrl,
+      headers,
+      validateStatus: status => [200, 201, 301, 302, 405, 207].includes(status)
+    });
+  }
+}
+
+async function uploadTickets() {
+  const credentials = getActiveCredentials();
+  if (!credentials) {
+    throw new Error('Aucun profil WebDAV actif trouvé. Vérifiez la variable d’environnement WEBDAV_ENDPOINTS.');
+  }
+
+  const { url, username, password, basePath } = credentials;
+  const headers = buildAuthHeader(username, password);
+
+  const files = await listLocalFiles(ticketsDir);
+  for (const file of files) {
+    const remotePath = normalizeRemotePath(basePath || '/tickets', file.relPath);
+    const remoteDir = path.posix.dirname(remotePath);
+    await ensureRemoteDir(url, headers, remoteDir);
+    const targetUrl = buildRemoteUrl(url, remotePath);
+    const stream = fs.createReadStream(file.absPath);
+    await axios.put(targetUrl, stream, {
+      headers: { ...headers, 'Content-Type': 'application/pdf' },
+      maxBodyLength: Infinity,
+      maxContentLength: Infinity
+    });
+  }
+
+  return files.length;
+}
+
+module.exports = { uploadTickets };


### PR DESCRIPTION
## Summary
- parse WebDAV endpoints from environment variables and persist mode/interval settings
- add scheduled and manual WebDAV uploads of ticket PDFs with API endpoints
- expose WebDAV scheduling controls and mode selection in the settings page

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925a79b31ec8327927b3d45074bfe6f)