### PR TITLE
Add GitHub auto-update support (electron-updater) and release documentation

### DIFF
--- a/electron-app/RELEASES.md
+++ b/electron-app/RELEASES.md
@@ -1,0 +1,79 @@
+# Publier une release GitHub compatible auto-update (Electron)
+
+Ce projet utilise `electron-updater` : l'application installée compare sa version locale avec la dernière release GitHub.
+
+Pour que ça fonctionne, il faut publier **les artefacts Electron Builder** (pas seulement un tag Git).
+
+## 1) Pré-requis GitHub
+
+1. Créer un repository GitHub (public ou privé).
+2. Créer un token GitHub avec droit `repo` (si privé) ou `public_repo` (si public).
+3. Exporter le token dans le shell :
+
+```bash
+export GH_TOKEN=ghp_xxx
+```
+
+> Sous Windows PowerShell :
+>
+> ```powershell
+> $env:GH_TOKEN="ghp_xxx"
+> ```
+
+## 2) Lier l'app à ton repo GitHub
+
+L'auto-update lit ces variables au runtime (dans `electron-app/main.js`) :
+
+- `BDD_CAISSE_GITHUB_OWNER`
+- `BDD_CAISSE_GITHUB_REPO`
+
+Exemple :
+
+```bash
+export BDD_CAISSE_GITHUB_OWNER=mon-org
+export BDD_CAISSE_GITHUB_REPO=bdd-caisse
+```
+
+## 3) Incrémenter la version
+
+Mettre à jour la version dans `electron-app/package.json` (ex: `1.2.2` -> `1.2.3`).
+
+## 4) Build + publication des artefacts release
+
+Depuis `electron-app/` :
+
+```bash
+npm run dist -- --publish always
+```
+
+Electron Builder va :
+
+- construire l'installeur (`.exe`),
+- générer les métadonnées (`latest.yml` + fichiers associés),
+- créer/mettre à jour la release GitHub,
+- uploader artefacts + métadonnées sur la release.
+
+## 5) Vérifier la release GitHub
+
+Dans la release, vérifier la présence de :
+
+- l'installeur Windows (`*.exe`),
+- `latest.yml`,
+- blocs (`*.blockmap` éventuels).
+
+Sans `latest.yml`, `electron-updater` ne peut pas déterminer la version/URL de mise à jour.
+
+## 6) Vérification côté app
+
+Lancer l'application packagée avec :
+
+- `BDD_CAISSE_GITHUB_OWNER`
+- `BDD_CAISSE_GITHUB_REPO`
+
+Au démarrage, elle doit logguer la vérification de MAJ et télécharger automatiquement si la version GitHub est plus récente.
+
+---
+
+## CI (optionnel mais recommandé)
+
+Tu peux automatiser le publish via GitHub Actions (`on: push tags`) avec `GH_TOKEN` en secret, pour éviter les publications manuelles.

--- a/electron-app/RELEASES.md
+++ b/electron-app/RELEASES.md
@@ -2,63 +2,80 @@
 
 Ce projet utilise `electron-updater` : l'application installée compare sa version locale avec les métadonnées publiées sur ton serveur WebDAV.
 
-Pour que ça fonctionne, il faut publier **les artefacts Electron Builder** (pas seulement un tag Git).
+Pour que ça fonctionne, il faut publier **les artefacts Electron Builder** (`latest.yml`, l'installateur et les blockmaps) dans un dossier WebDAV accessible en lecture.
 
 ## 1) Pré-requis serveur WebDAV
 
-1. Disposer d'un dossier distant WebDAV dédié aux releases (ex: `https://mon-serveur/webdav/bdd-caisse/releases/`).
-2. Avoir les accès en écriture (upload des artefacts).
+1. Disposer d'un endpoint WebDAV déjà déclaré dans `backend/.env` via `WEBDAV_ENDPOINTS`.
+2. Avoir les accès en écriture pour uploader les artefacts générés.
+3. Prévoir un dossier distant dédié aux releases (par défaut `/releases`).
 
-## 2) Lier l'app à ton endpoint WebDAV
+## 2) Configuration utilisée par l'application
 
-L'auto-update lit cette variable au runtime (dans `electron-app/main.js`) :
+L'auto-update ne lit plus `BDD_CAISSE_UPDATE_URL`. Il réutilise les accès déjà déclarés dans `backend/.env` via `WEBDAV_ENDPOINTS`.
 
-- `BDD_CAISSE_UPDATE_URL`
+Exemple de profil :
 
-Exemple :
-
-```bash
-export BDD_CAISSE_UPDATE_URL=https://mon-serveur/webdav/bdd-caisse/releases/
+```json
+{
+  "production": {
+    "label": "Serveur production",
+    "url": "https://mon-serveur/webdav/",
+    "username": "utilisateur",
+    "password": "motdepasse",
+    "basePath": "/tickets",
+    "updatePath": "/releases"
+  }
+}
 ```
+
+Notes :
+
+- `url`, `username` et `password` sont obligatoires.
+- `updatePath` indique le dossier qui contiendra `latest.yml` et l'installateur.
+- Si `updatePath` est absent, l'application utilise `/releases` par défaut.
+- Le profil actif est celui enregistré dans la configuration WebDAV de l'application ; sinon le premier profil de `WEBDAV_ENDPOINTS` est utilisé.
 
 ## 3) Incrémenter la version
 
 Mettre à jour la version dans `electron-app/package.json` (ex: `1.2.2` -> `1.2.3`).
 
-## 4) Build + publication des artefacts release
+## 4) Build des artefacts release
 
-Depuis `electron-app/` (sans publication GitHub) :
+Depuis `electron-app/` :
 
 ```bash
-npm run dist -- --publish never
+npm run dist
 ```
 
-Electron Builder va générer dans `dist/` :
+Le script `dist` lance `electron-builder --publish never`. La configuration `build.publish` du `package.json` force Electron Builder à générer les métadonnées d'auto-update, dont `latest.yml`, sans publier automatiquement sur GitHub.
 
-- l'installeur (`.exe`),
+Electron Builder génère dans `dist/` :
+
+- l'installateur Windows (`*.exe`),
 - les métadonnées (`latest.yml` + fichiers associés),
 - les fichiers de blockmap (`*.blockmap` éventuels).
 
-Ensuite, uploader ces fichiers dans ton dossier WebDAV de release.
+## 5) Upload WebDAV
 
-## 5) Vérifier le dossier de release WebDAV
+Uploader tous les fichiers générés nécessaires dans le dossier WebDAV configuré par `updatePath`.
 
-Vérifier la présence de :
+Exemple avec le profil ci-dessus :
 
-- l'installeur Windows (`*.exe`),
-- `latest.yml`,
-- blocs (`*.blockmap` éventuels).
-
-Sans `latest.yml`, `electron-updater` ne peut pas déterminer la version/URL de mise à jour.
+```text
+https://mon-serveur/webdav/releases/latest.yml
+https://mon-serveur/webdav/releases/Bdd-caisse Setup 1.2.3.exe
+https://mon-serveur/webdav/releases/Bdd-caisse Setup 1.2.3.exe.blockmap
+```
 
 ## 6) Vérification côté app
 
-Lancer l'application packagée avec `BDD_CAISSE_UPDATE_URL` pointant vers le dossier WebDAV qui contient `latest.yml`.
+Au démarrage, ou via le bouton **Rechercher une mise à jour** dans les paramètres, l'application :
 
-Au démarrage, elle doit logguer la vérification de MAJ et télécharger automatiquement si la version distante est plus récente.
+1. lit `backend/.env`,
+2. récupère `WEBDAV_ENDPOINTS`,
+3. sélectionne le profil WebDAV actif,
+4. pointe `electron-updater` vers `url + updatePath`,
+5. télécharge automatiquement la mise à jour si la version distante est plus récente.
 
----
-
-## CI (optionnel mais recommandé)
-
-Tu peux automatiser le build puis l'upload WebDAV via CI/CD (GitHub Actions, GitLab CI, etc.) pour éviter les publications manuelles.
+Sans `latest.yml` dans ce dossier, `electron-updater` ne peut pas déterminer la version/URL de mise à jour.

--- a/electron-app/RELEASES.md
+++ b/electron-app/RELEASES.md
@@ -1,37 +1,24 @@
-# Publier une release GitHub compatible auto-update (Electron)
+# Publier une release WebDAV compatible auto-update (Electron)
 
-Ce projet utilise `electron-updater` : l'application installée compare sa version locale avec la dernière release GitHub.
+Ce projet utilise `electron-updater` : l'application installée compare sa version locale avec les métadonnées publiées sur ton serveur WebDAV.
 
 Pour que ça fonctionne, il faut publier **les artefacts Electron Builder** (pas seulement un tag Git).
 
-## 1) Pré-requis GitHub
+## 1) Pré-requis serveur WebDAV
 
-1. Créer un repository GitHub (public ou privé).
-2. Créer un token GitHub avec droit `repo` (si privé) ou `public_repo` (si public).
-3. Exporter le token dans le shell :
+1. Disposer d'un dossier distant WebDAV dédié aux releases (ex: `https://mon-serveur/webdav/bdd-caisse/releases/`).
+2. Avoir les accès en écriture (upload des artefacts).
 
-```bash
-export GH_TOKEN=ghp_xxx
-```
+## 2) Lier l'app à ton endpoint WebDAV
 
-> Sous Windows PowerShell :
->
-> ```powershell
-> $env:GH_TOKEN="ghp_xxx"
-> ```
+L'auto-update lit cette variable au runtime (dans `electron-app/main.js`) :
 
-## 2) Lier l'app à ton repo GitHub
-
-L'auto-update lit ces variables au runtime (dans `electron-app/main.js`) :
-
-- `BDD_CAISSE_GITHUB_OWNER`
-- `BDD_CAISSE_GITHUB_REPO`
+- `BDD_CAISSE_UPDATE_URL`
 
 Exemple :
 
 ```bash
-export BDD_CAISSE_GITHUB_OWNER=mon-org
-export BDD_CAISSE_GITHUB_REPO=bdd-caisse
+export BDD_CAISSE_UPDATE_URL=https://mon-serveur/webdav/bdd-caisse/releases/
 ```
 
 ## 3) Incrémenter la version
@@ -40,22 +27,23 @@ Mettre à jour la version dans `electron-app/package.json` (ex: `1.2.2` -> `1.2.
 
 ## 4) Build + publication des artefacts release
 
-Depuis `electron-app/` :
+Depuis `electron-app/` (sans publication GitHub) :
 
 ```bash
-npm run dist -- --publish always
+npm run dist -- --publish never
 ```
 
-Electron Builder va :
+Electron Builder va générer dans `dist/` :
 
-- construire l'installeur (`.exe`),
-- générer les métadonnées (`latest.yml` + fichiers associés),
-- créer/mettre à jour la release GitHub,
-- uploader artefacts + métadonnées sur la release.
+- l'installeur (`.exe`),
+- les métadonnées (`latest.yml` + fichiers associés),
+- les fichiers de blockmap (`*.blockmap` éventuels).
 
-## 5) Vérifier la release GitHub
+Ensuite, uploader ces fichiers dans ton dossier WebDAV de release.
 
-Dans la release, vérifier la présence de :
+## 5) Vérifier le dossier de release WebDAV
+
+Vérifier la présence de :
 
 - l'installeur Windows (`*.exe`),
 - `latest.yml`,
@@ -65,15 +53,12 @@ Sans `latest.yml`, `electron-updater` ne peut pas déterminer la version/URL de 
 
 ## 6) Vérification côté app
 
-Lancer l'application packagée avec :
+Lancer l'application packagée avec `BDD_CAISSE_UPDATE_URL` pointant vers le dossier WebDAV qui contient `latest.yml`.
 
-- `BDD_CAISSE_GITHUB_OWNER`
-- `BDD_CAISSE_GITHUB_REPO`
-
-Au démarrage, elle doit logguer la vérification de MAJ et télécharger automatiquement si la version GitHub est plus récente.
+Au démarrage, elle doit logguer la vérification de MAJ et télécharger automatiquement si la version distante est plus récente.
 
 ---
 
 ## CI (optionnel mais recommandé)
 
-Tu peux automatiser le publish via GitHub Actions (`on: push tags`) avec `GH_TOKEN` en secret, pour éviter les publications manuelles.
+Tu peux automatiser le build puis l'upload WebDAV via CI/CD (GitHub Actions, GitLab CI, etc.) pour éviter les publications manuelles.

--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -13,8 +13,8 @@ let backendProcess;
 let _ensuring = false;
 let _lastEnsure = 0;
 
-const GITHUB_OWNER = process.env.BDD_CAISSE_GITHUB_OWNER;
-const GITHUB_REPO = process.env.BDD_CAISSE_GITHUB_REPO;
+const UPDATE_BASE_URL = process.env.BDD_CAISSE_UPDATE_URL;
+let autoUpdaterConfigured = false;
 
 function setupAutoUpdaterLogs() {
   autoUpdater.on('checking-for-update', () => {
@@ -46,36 +46,46 @@ function setupAutoUpdaterLogs() {
   });
 }
 
-async function checkForAppUpdate() {
-  if (!app.isPackaged) {
-    console.log('ℹ️ Mode développement: vérification de mise à jour ignorée.');
-    return;
-  }
+function configureAutoUpdater() {
+  if (autoUpdaterConfigured) return true;
 
-  if (!GITHUB_OWNER || !GITHUB_REPO) {
-    console.warn('⚠️ Mise à jour auto désactivée: définissez BDD_CAISSE_GITHUB_OWNER et BDD_CAISSE_GITHUB_REPO.');
-    return;
+  if (!UPDATE_BASE_URL) {
+    console.warn('⚠️ Mise à jour auto désactivée: définissez BDD_CAISSE_UPDATE_URL.');
+    return false;
   }
 
   setupAutoUpdaterLogs();
-
   autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = true;
   autoUpdater.allowPrerelease = false;
-
   autoUpdater.setFeedURL({
-    provider: 'github',
-    owner: GITHUB_OWNER,
-    repo: GITHUB_REPO
+    provider: 'generic',
+    url: UPDATE_BASE_URL
   });
+  autoUpdaterConfigured = true;
+  console.log(`🌐 Source de mise à jour configurée : ${UPDATE_BASE_URL}`);
+  return true;
+}
+
+async function checkForAppUpdate(source = 'startup') {
+  if (!app.isPackaged) {
+    console.log(`ℹ️ Mode développement: vérification de mise à jour ignorée (${source}).`);
+    return { success: false, message: 'Mode développement' };
+  }
+
+  if (!configureAutoUpdater()) {
+    return { success: false, message: 'BDD_CAISSE_UPDATE_URL manquante' };
+  }
 
   try {
     const result = await autoUpdater.checkForUpdates();
     if (result?.updateInfo?.version) {
-      console.log(`🆚 Version locale ${app.getVersion()} / GitHub ${result.updateInfo.version}`);
+      console.log(`🆚 Version locale ${app.getVersion()} / distante ${result.updateInfo.version} (${source})`);
     }
+    return { success: true, version: result?.updateInfo?.version || app.getVersion() };
   } catch (error) {
-    console.error('❌ Impossible de vérifier les mises à jour GitHub :', error?.message || error);
+    console.error('❌ Impossible de vérifier les mises à jour distantes :', error?.message || error);
+    return { success: false, message: error?.message || 'Erreur inconnue' };
   }
 }
 
@@ -115,6 +125,9 @@ function ensureInteractiveRaise() {
 // IPC
 ipcMain.handle('ui/ensure-interactive-light', () => { ensureInteractiveLight(); return true; });
 ipcMain.handle('ui/ensure-interactive-raise', () => { ensureInteractiveRaise(); return true; });
+ipcMain.handle('app/check-for-updates', async () => {
+  return checkForAppUpdate('manual');
+});
 
 function createWindow() {
   mainWindow = new BrowserWindow({

--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -13,12 +13,111 @@ let backendProcess;
 let _ensuring = false;
 let _lastEnsure = 0;
 
-const UPDATE_BASE_URL = process.env.BDD_CAISSE_UPDATE_URL;
 let autoUpdaterConfigured = false;
+
+function getBackendDir() {
+  return app.isPackaged
+    ? path.join(process.resourcesPath, 'backend')
+    : path.join(__dirname, '../backend');
+}
+
+function parseEnvContent(content) {
+  return content.split(/\r?\n/).reduce((acc, line) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) return acc;
+
+    const separatorIndex = trimmed.indexOf('=');
+    if (separatorIndex === -1) return acc;
+
+    const key = trimmed.slice(0, separatorIndex).trim();
+    let value = trimmed.slice(separatorIndex + 1).trim();
+    if (!key) return acc;
+
+    const quote = value[0];
+    const isQuoted = (quote === '"' || quote === "'") && value.endsWith(quote);
+    if (isQuoted) {
+      value = value.slice(1, -1);
+    }
+
+    if (quote === '"') {
+      value = value.replace(/\\"/g, '"');
+    }
+
+    acc[key] = value.replace(/\\n/g, '\n').replace(/\\r/g, '\r');
+    return acc;
+  }, {});
+}
+
+function loadBackendEnv() {
+  const envPath = path.join(getBackendDir(), '.env');
+  if (!fs.existsSync(envPath)) return {};
+
+  try {
+    return parseEnvContent(fs.readFileSync(envPath, 'utf8'));
+  } catch (error) {
+    console.error('❌ Impossible de lire le fichier .env backend :', error?.message || error);
+    return {};
+  }
+}
+
+function loadWebdavEndpoints() {
+  const backendEnv = loadBackendEnv();
+  const raw = process.env.WEBDAV_ENDPOINTS || backendEnv.WEBDAV_ENDPOINTS || process.env.WEBDAV_CONFIG || backendEnv.WEBDAV_CONFIG;
+  if (!raw) return {};
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return {};
+    return parsed;
+  } catch (error) {
+    console.error('❌ WEBDAV_ENDPOINTS invalide pour la mise à jour :', error?.message || error);
+    return {};
+  }
+}
+
+function loadPersistedWebdavMode(endpoints) {
+  const configPath = path.join(app.getPath('home'), '.bdd-caisse', 'webdavSyncConfig.json');
+  if (!fs.existsSync(configPath)) return Object.keys(endpoints)[0] || null;
+
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    if (config?.mode && endpoints[config.mode]) return config.mode;
+  } catch {}
+
+  return Object.keys(endpoints)[0] || null;
+}
+
+function buildBasicAuthHeader(username, password) {
+  const token = Buffer.from(`${username}:${password}`).toString('base64');
+  return `Basic ${token}`;
+}
+
+function buildWebdavUpdateConfig() {
+  const endpoints = loadWebdavEndpoints();
+  const activeMode = loadPersistedWebdavMode(endpoints);
+  const endpoint = activeMode ? endpoints[activeMode] : null;
+
+  if (!endpoint?.url || !endpoint?.username || !endpoint?.password) {
+    return null;
+  }
+
+  const updatePath = endpoint.updatePath || endpoint.releasePath || endpoint.releasesPath || '/releases';
+  const normalizedBase = endpoint.url.endsWith('/') ? endpoint.url : `${endpoint.url}/`;
+  const normalizedPath = String(updatePath).replace(/^\/+/, '').replace(/\/+$/, '');
+  const updateUrl = new URL(`${normalizedPath}/`, normalizedBase).toString();
+
+  return {
+    url: updateUrl,
+    mode: activeMode,
+    requestHeaders: {
+      Authorization: buildBasicAuthHeader(endpoint.username, endpoint.password)
+    }
+  };
+}
 
 function setupAutoUpdaterLogs() {
   autoUpdater.on('checking-for-update', () => {
-    console.log('🔎 Vérification des mises à jour GitHub...');
+    console.log('🔎 Vérification des mises à jour WebDAV...');
   });
 
   autoUpdater.on('update-not-available', (info) => {
@@ -49,8 +148,9 @@ function setupAutoUpdaterLogs() {
 function configureAutoUpdater() {
   if (autoUpdaterConfigured) return true;
 
-  if (!UPDATE_BASE_URL) {
-    console.warn('⚠️ Mise à jour auto désactivée: définissez BDD_CAISSE_UPDATE_URL.');
+  const webdavUpdateConfig = buildWebdavUpdateConfig();
+  if (!webdavUpdateConfig) {
+    console.warn('⚠️ Mise à jour auto désactivée: aucun endpoint WEBDAV_ENDPOINTS exploitable trouvé dans backend/.env.');
     return false;
   }
 
@@ -60,10 +160,11 @@ function configureAutoUpdater() {
   autoUpdater.allowPrerelease = false;
   autoUpdater.setFeedURL({
     provider: 'generic',
-    url: UPDATE_BASE_URL
+    url: webdavUpdateConfig.url,
+    requestHeaders: webdavUpdateConfig.requestHeaders
   });
   autoUpdaterConfigured = true;
-  console.log(`🌐 Source de mise à jour configurée : ${UPDATE_BASE_URL}`);
+  console.log(`🌐 Source de mise à jour WebDAV configurée (${webdavUpdateConfig.mode}) : ${webdavUpdateConfig.url}`);
   return true;
 }
 
@@ -74,7 +175,7 @@ async function checkForAppUpdate(source = 'startup') {
   }
 
   if (!configureAutoUpdater()) {
-    return { success: false, message: 'BDD_CAISSE_UPDATE_URL manquante' };
+    return { success: false, message: 'Aucun endpoint WEBDAV_ENDPOINTS exploitable pour les mises à jour' };
   }
 
   try {

--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -1,5 +1,6 @@
-const { app, BrowserWindow, Menu, ipcMain, shell } = require('electron');
+const { app, BrowserWindow, Menu, ipcMain, shell, dialog } = require('electron');
 const { session: electronSession } = require('electron');
+const { autoUpdater } = require('electron-updater');
 
 const path = require('path');
 const fs = require('fs');
@@ -11,6 +12,72 @@ let mainWindow;
 let backendProcess;
 let _ensuring = false;
 let _lastEnsure = 0;
+
+const GITHUB_OWNER = process.env.BDD_CAISSE_GITHUB_OWNER;
+const GITHUB_REPO = process.env.BDD_CAISSE_GITHUB_REPO;
+
+function setupAutoUpdaterLogs() {
+  autoUpdater.on('checking-for-update', () => {
+    console.log('🔎 Vérification des mises à jour GitHub...');
+  });
+
+  autoUpdater.on('update-not-available', (info) => {
+    console.log(`✅ Version locale à jour (${info?.version || app.getVersion()})`);
+  });
+
+  autoUpdater.on('error', (error) => {
+    console.error('❌ Erreur pendant la mise à jour automatique :', error?.message || error);
+  });
+
+  autoUpdater.on('download-progress', (progress) => {
+    const percent = Math.round(progress?.percent || 0);
+    console.log(`⬇️ Téléchargement mise à jour : ${percent}%`);
+  });
+
+  autoUpdater.on('update-downloaded', async (info) => {
+    console.log(`📦 Mise à jour ${info.version} téléchargée. Installation...`);
+    await dialog.showMessageBox({
+      type: 'info',
+      title: 'Mise à jour disponible',
+      message: `La version ${info.version} a été téléchargée. L'application va redémarrer pour finaliser la mise à jour.`
+    });
+
+    setImmediate(() => autoUpdater.quitAndInstall());
+  });
+}
+
+async function checkForAppUpdate() {
+  if (!app.isPackaged) {
+    console.log('ℹ️ Mode développement: vérification de mise à jour ignorée.');
+    return;
+  }
+
+  if (!GITHUB_OWNER || !GITHUB_REPO) {
+    console.warn('⚠️ Mise à jour auto désactivée: définissez BDD_CAISSE_GITHUB_OWNER et BDD_CAISSE_GITHUB_REPO.');
+    return;
+  }
+
+  setupAutoUpdaterLogs();
+
+  autoUpdater.autoDownload = true;
+  autoUpdater.autoInstallOnAppQuit = true;
+  autoUpdater.allowPrerelease = false;
+
+  autoUpdater.setFeedURL({
+    provider: 'github',
+    owner: GITHUB_OWNER,
+    repo: GITHUB_REPO
+  });
+
+  try {
+    const result = await autoUpdater.checkForUpdates();
+    if (result?.updateInfo?.version) {
+      console.log(`🆚 Version locale ${app.getVersion()} / GitHub ${result.updateInfo.version}`);
+    }
+  } catch (error) {
+    console.error('❌ Impossible de vérifier les mises à jour GitHub :', error?.message || error);
+  }
+}
 
 
 function ensureInteractiveLight() {
@@ -263,7 +330,9 @@ function waitForBackendReady(callback) {
 }
 
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
+  await checkForAppUpdate();
+
   if (!isDev) {
     launchBackend();
     waitForBackendReady(() => {

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "electron .",
     "pack": "electron-builder --dir",
-    "dist": "electron-builder",
+    "dist": "electron-builder --publish never",
     "copy-react-build": "rm -rf build && cp -r ../frontend/build ./build"
   },
   "build": {
@@ -39,25 +39,25 @@
         "to": "node.exe"
       },
       {
-      "from": "../backend/database/ressourcebrie-sqlite-template.db",
-      "to": "database"
-    },
-    {
-      "from": "../backend/inserts_categories_boutons.sql",
-      "to": "."
-    },
-    {
-      "from": "../backend/inserts_users.sql",
-      "to": "."
-    },
-    {
-      "from": "../frontend/src/images",
-      "to": "images"
-    },
-    {
-    "from": "../frontend/build",
-    "to": "frontend_build"
-  }
+        "from": "../backend/database/ressourcebrie-sqlite-template.db",
+        "to": "database"
+      },
+      {
+        "from": "../backend/inserts_categories_boutons.sql",
+        "to": "."
+      },
+      {
+        "from": "../backend/inserts_users.sql",
+        "to": "."
+      },
+      {
+        "from": "../frontend/src/images",
+        "to": "images"
+      },
+      {
+        "from": "../frontend/build",
+        "to": "frontend_build"
+      }
     ],
     "directories": {
       "buildResources": "assets"
@@ -65,7 +65,13 @@
     "win": {
       "target": "nsis",
       "icon": "assets/icon.ico"
-    }
+    },
+    "publish": [
+      {
+        "provider": "generic",
+        "url": "https://example.invalid/bdd-caisse/releases/"
+      }
+    ]
   },
   "dependencies": {
     "electron-updater": "^6.6.2"

--- a/electron-app/preload.js
+++ b/electron-app/preload.js
@@ -5,6 +5,7 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('electron', {
   openPdf: (relativePath) => ipcRenderer.send('open-pdf', relativePath),
   ouvrirDevTools: () => ipcRenderer.send('devtools-open'),
-ensureInteractiveLight: () => ipcRenderer.invoke('ui/ensure-interactive-light'),
-  ensureInteractiveRaise: () => ipcRenderer.invoke('ui/ensure-interactive-raise')
+  ensureInteractiveLight: () => ipcRenderer.invoke('ui/ensure-interactive-light'),
+  ensureInteractiveRaise: () => ipcRenderer.invoke('ui/ensure-interactive-raise'),
+  checkForUpdates: () => ipcRenderer.invoke('app/check-for-updates')
 });

--- a/frontend/src/pages/Parametres.jsx
+++ b/frontend/src/pages/Parametres.jsx
@@ -35,6 +35,7 @@ const [showBoutons, setShowBoutons] = useState(false);
   const [webdavMessage, setWebdavMessage] = useState('');
   const [webdavModes, setWebdavModes] = useState([]);
   const [webdavState, setWebdavState] = useState(null);
+  const [updateMessage, setUpdateMessage] = useState('');
 
   const [showPassModal, setShowPassModal] = useState(false);
   const { devMode, setDevMode } = useContext(DevModeContext);
@@ -243,6 +244,24 @@ const [showBoutons, setShowBoutons] = useState(false);
       setWebdavMessage('❌ Erreur pendant la synchronisation');
     }
   };
+  const checkForAppUpdates = async () => {
+    setUpdateMessage('');
+    if (!window.electron?.checkForUpdates) {
+      setUpdateMessage("❌ Vérification indisponible hors application Electron packagée.");
+      return;
+    }
+
+    try {
+      const result = await window.electron.checkForUpdates();
+      if (result?.success) {
+        setUpdateMessage(`✅ Vérification lancée (version distante: ${result.version || 'inconnue'}).`);
+      } else {
+        setUpdateMessage(`❌ ${result?.message || 'Impossible de vérifier la mise à jour.'}`);
+      }
+    } catch {
+      setUpdateMessage('❌ Erreur lors de la vérification de mise à jour.');
+    }
+  };
 
   useEffect(() => {
   console.log('🧪 window.electron:', window.electron);
@@ -336,6 +355,13 @@ const [showBoutons, setShowBoutons] = useState(false);
           <small>Dernier envoi : {new Date(webdavState.lastRun).toLocaleString()} {webdavState.lastResult === 'error' && `- ${webdavState.error || ''}`}</small>
         </div>
       )}
+
+      <hr />
+
+      <h3>⬆️ Mise à jour application</h3>
+      <p className="mb-2">Vérifie immédiatement s'il existe une nouvelle version sur le serveur de release WebDAV.</p>
+      <Button variant="secondary" onClick={checkForAppUpdates}>🔎 Rechercher une mise à jour</Button>
+      {updateMessage && <div className="mt-2">{updateMessage}</div>}
 
       <hr />
 


### PR DESCRIPTION
### Motivation
- Enable automatic updates for the packaged Electron app using GitHub releases so installed clients can auto-update via `electron-updater`.
- Provide clear, reproducible instructions for publishing Electron Builder artifacts to GitHub so `electron-updater` can find `latest.yml` and installers.

### Description
- Add `electron-app/RELEASES.md` with step-by-step instructions (in French) for creating a GitHub token, configuring `BDD_CAISSE_GITHUB_OWNER`/`BDD_CAISSE_GITHUB_REPO`, incrementing `package.json` version, and publishing artifacts with `npm run dist -- --publish always`.
- Update `electron-app/main.js` to import `autoUpdater` and `dialog`, read `BDD_CAISSE_GITHUB_OWNER`/`BDD_CAISSE_GITHUB_REPO` from the environment, and add `setupAutoUpdaterLogs()` to log update lifecycle events.
- Add `checkForAppUpdate()` which configures `autoUpdater` (feed URL, `autoDownload`, `autoInstallOnAppQuit`, `allowPrerelease`), only runs when `app.isPackaged` and env vars are set, and triggers `quitAndInstall()` after showing a message box when an update is downloaded.
- Call `await checkForAppUpdate()` from `app.whenReady()` so update checks run at startup (skipped in development), while preserving backend launch and window creation flow.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e400d78883278253fa9ebb641b35)