### PR TITLE
Improve publish build feedback, add WebDAV timeout, disable CRA sourcemaps and clean frontend warnings

### DIFF
--- a/electron-app/scripts/build-release.js
+++ b/electron-app/scripts/build-release.js
@@ -25,6 +25,7 @@ function ask(question, defaultValue = '') {
 }
 
 function runElectronBuilder() {
+  console.log('🏗️ Construction des artefacts Electron avec electron-builder...');
   const npx = process.platform === 'win32' ? 'npx.cmd' : 'npx';
   const result = spawnSync(npx, ['electron-builder', '--publish', 'never'], {
     cwd: appDir,
@@ -35,6 +36,8 @@ function runElectronBuilder() {
   if (result.status !== 0) {
     process.exit(result.status || 1);
   }
+
+  console.log('✅ Artefacts Electron générés dans electron-app/dist/.');
 }
 
 function getReleaseNotes() {
@@ -120,6 +123,11 @@ function uploadFile(baseUrl, file) {
       });
     });
 
+    const timeoutMs = Number(process.env.BDD_CAISSE_UPLOAD_TIMEOUT_MS || 120000);
+    request.setTimeout(timeoutMs, () => {
+      request.destroy(new Error(`Upload ${file.fileName} interrompu après ${timeoutMs / 1000}s sans réponse.`));
+    });
+
     request.on('error', reject);
     fs.createReadStream(file.fullPath).pipe(request);
   });
@@ -130,6 +138,8 @@ async function publishToWebdav() {
   if (!updateUrl) {
     throw new Error('BDD_CAISSE_UPDATE_URL doit pointer vers le dossier WebDAV de release.');
   }
+
+  console.log(`🌐 Publication WebDAV vers ${updateUrl}`);
 
   const releaseNotes = getReleaseNotes();
   injectReleaseNotes(releaseNotes);
@@ -147,10 +157,14 @@ async function publishToWebdav() {
 }
 
 async function main() {
-  runElectronBuilder();
-
   let shouldPublish = args.has('--publish');
   if (args.has('--no-publish')) shouldPublish = false;
+
+  if (shouldPublish && !process.env.BDD_CAISSE_UPDATE_URL) {
+    throw new Error('BDD_CAISSE_UPDATE_URL doit pointer vers le dossier WebDAV de release avant de lancer --publish. Utilise npm run package:no-publish pour construire sans publier.');
+  }
+
+  runElectronBuilder();
 
   if (!args.has('--publish') && !args.has('--no-publish')) {
     const answer = await ask('Publier cette mise à jour sur le serveur WebDAV ? [o/N] ', 'n');

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,3 @@
+# Les sourcemaps de production ne sont pas nécessaires pour l'application packagée.
+# Cela évite les avertissements CRA liés aux sourcemaps incomplètes de dépendances npm.
+GENERATE_SOURCEMAP=false

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,22 +1,13 @@
-import { io } from 'socket.io-client';
-import { useEffect, useState, createContext } from 'react';
+import { useEffect } from 'react';
 import MainRoutes from './components/MainRoutes';
 import MainNavbar from './components/MainNavBar';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import './styles/App.scss';
-import { useLocation } from 'react-router-dom';
 import BilanJour from './components/BilanJour';
 import { SyncModalProvider } from './contexts/SyncModalContext';
 import ModalSyncSecondaire from './components/ModalSyncSecondaire';
 //import FocusHud from './components/FocusHud';
-
-
-
-
-
-// Ces deux lignes doivent venir **après** tous les imports
-const socket = io('http://localhost:3001');
 
 function App() {
 

--- a/frontend/src/components/CorrectionModal.jsx
+++ b/frontend/src/components/CorrectionModal.jsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useRef } from 'react';
 import { Modal, Button, Form } from 'react-bootstrap';
 import CategorieSelector from './CategorieSelector';
 import BoutonsCaisse from './BoutonsCaisse';
-import { useSessionCaisse } from '../contexts/SessionCaisseContext';
 import TactileInput from './TactileInput';
 import { useActiveSession } from '../contexts/SessionCaisseContext';
 import ResponsableForm from "./ResponsableForm";
@@ -306,16 +305,6 @@ const handleCancelCustomMotif = () => {
     setArticlesSupprimes(articlesSupprimes.slice(0, -1));
   };
 
-  // Calcule le total avant réduction initiale (pour affichage) - Keep as is
-  const totalAvantReductionInitiale = () => {
-    if (!reductionOriginale) return totalAvant;
-    if (reductionOriginale === 'trueClient') return totalAvant + 500;
-    if (reductionOriginale === 'trueBene') return totalAvant + 1000;
-    if (reductionOriginale === 'trueGrosPanierClient') return Math.round(totalAvant / 0.9);
-    if (reductionOriginale === 'trueGrosPanierBene') return Math.round(totalAvant / 0.8);
-    return totalAvant;
-  };
-
   // Calcule le total après application de la réduction sélectionnée
   const totalApresReduction = () => {
     const totalSansReduction = corrections
@@ -394,16 +383,18 @@ const handleCancelCustomMotif = () => {
 
   useEffect(() => {
     // Adjust payments automatically when totalCorrige changes and only one payment method is present
-    if (paiements.length === 1) {
-      const montantActuel = parseMontant(paiements[0].montant);
-      if (montantActuel !== totalCorrige) {
-        setPaiements([{
-          ...paiements[0],
-          montant: (totalCorrige / 100).toFixed(2).replace('.', ',')
-        }]);
-      }
-    }
-  }, [totalCorrige, paiements.length]); // Added paiements.length as a dependency
+    setPaiements((currentPaiements) => {
+      if (currentPaiements.length !== 1) return currentPaiements;
+
+      const montantActuel = parseMontant(currentPaiements[0].montant);
+      if (montantActuel === totalCorrige) return currentPaiements;
+
+      return [{
+        ...currentPaiements[0],
+        montant: (totalCorrige / 100).toFixed(2).replace('.', ',')
+      }];
+    });
+  }, [totalCorrige]);
 
 
   // Envoie la correction au backend après vérifications

--- a/frontend/src/components/DevModeModal.jsx
+++ b/frontend/src/components/DevModeModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Modal, Button, Form } from 'react-bootstrap';
+import { Modal, Button } from 'react-bootstrap';
 import TactileInput from '../components/TactileInput';
 
 

--- a/frontend/src/components/MainRoutes.jsx
+++ b/frontend/src/components/MainRoutes.jsx
@@ -13,16 +13,11 @@ import Parametres from '../pages/Parametres';
 import RequireUserSession from './RequireUserSession';
 import RequireUserAndCaisseSession from './RequireUserAndCaisseSession';
 import CaisseNonOuverte from '../pages/CaisseNonOuverte';
-import { useActiveSession } from '../contexts/SessionCaisseContext';
-import SessionCaisseAutoProvider from '../contexts/SessionCaisseAutoProvider';
-import { SessionCaisseProvider, SessionCaisseSecondaireProvider } from '../contexts/SessionCaisseContext';
 import { useContext } from 'react';
 import { DevModeContext } from '../contexts/DevModeContext';
 
 export default function MainRoutes() {
   const { devMode } = useContext(DevModeContext);
-  const activeSession = useActiveSession();
-
   return (
     <Routes>
       

--- a/frontend/src/components/ValidationVente.jsx
+++ b/frontend/src/components/ValidationVente.jsx
@@ -244,35 +244,6 @@ function ValidationVente({ total, id_temp_vente, onValide }) {
   // 🧮💶 ==================  Calculette "Espèces"  ==================
   const cashGivenCents = parseMontant(montantDonne);
   const changeCents = Math.max(cashGivenCents - totalAvecReduction, 0);
-  const manqueCents = Math.max(totalAvecReduction - cashGivenCents, 0);
-  const peutValiderCash = cashGivenCents >= totalAvecReduction;
-
-  const addToMontantDonne = (addCents) => {
-    const newCents = cashGivenCents + addCents;
-    setMontantDonne(fmtEuros(newCents));
-  };
-  const setExact = () => setMontantDonne(fmtEuros(totalAvecReduction));
-  const clearMontant = () => setMontantDonne('');
-
-  const appendChar = (char) => {
-    // mini pavé numérique
-    if (char === '←') {
-      setMontantDonne((prev) => (prev || '').slice(0, -1));
-    } else if (char === ',' && !(montantDonne || '').includes(',')) {
-      setMontantDonne((prev) => (prev || '') + ',');
-    } else if (/^\d$/.test(char)) {
-      setMontantDonne((prev) => (prev || '') + char);
-    } else if (char === 'C') {
-      clearMontant();
-    }
-  };
-
-  const quickNextMultiple = (stepCents) => {
-    const due = totalAvecReduction;
-    const next = Math.ceil(due / stepCents) * stepCents;
-    return next;
-  };
-
   // =================================================================
 
   const formulairePaiements = (

--- a/frontend/src/contexts/SessionCaisseContext.js
+++ b/frontend/src/contexts/SessionCaisseContext.js
@@ -1,5 +1,5 @@
 // src/contexts/SessionCaisseContext.jsx
-import React, { createContext, useState, useEffect, useContext } from 'react';
+import React, { createContext, useState, useEffect, useContext, useCallback } from 'react';
 import socket from '../utils/socket';
 
 const SessionCaisseContext = createContext();
@@ -29,7 +29,7 @@ export function SessionCaisseProvider({ children }) {
   const [sessionCaisseOuverte, setSessionCaisseOuverte] = useState(false);
   const [isReady, setIsReady] = useState(false); // ✅ NEW
 
-  const refreshSessionCaisse = () => {
+  const refreshSessionCaisse = useCallback(() => {
     // on retourne la Promise pour pouvoir await dans useEffect
     return fetch('http://localhost:3001/api/session/etat-caisse', { credentials: 'include' })
       .then(res => res.json())
@@ -46,7 +46,7 @@ export function SessionCaisseProvider({ children }) {
         setUuidSessionCaisse(null);
         setSessionCaisseOuverte(false);
       });
-  };
+  }, []);
 
   useEffect(() => {
     (async () => {
@@ -64,7 +64,7 @@ export function SessionCaisseProvider({ children }) {
 
     socket.on('etatCaisseUpdated', handler);
     return () => socket.off('etatCaisseUpdated', handler);
-  }, []);
+  }, [refreshSessionCaisse]);
 
   return (
     <SessionCaisseContext.Provider value={{
@@ -92,7 +92,7 @@ export function SessionCaisseSecondaireProvider({ children }) {
   const [caisseSecondaireActive, setCaisseSecondaireActive] = useState(false);
   const [isReady, setIsReady] = useState(false); // ✅ NEW
 
-  const refreshCaisseSecondaire = () => {
+  const refreshCaisseSecondaire = useCallback(() => {
     return fetch('http://localhost:3001/api/session/etat-caisse-secondaire', { credentials: 'include' })
       .then(res => res.json())
       .then(data => {
@@ -108,7 +108,7 @@ export function SessionCaisseSecondaireProvider({ children }) {
         setUuidCaisseSecondaire(null);
         setCaisseSecondaireActive(false);
       });
-  };
+  }, [sessionCaisseOuverte]);
 
   useEffect(() => {
     if (!principaleReady) return; // ✅ tant que le principal n’a pas fini son 1er fetch, on attend
@@ -126,7 +126,7 @@ export function SessionCaisseSecondaireProvider({ children }) {
 
     socket.on('etatCaisseUpdated', handler);
     return () => socket.off('etatCaisseUpdated', handler);
-  }, [principaleReady, sessionCaisseOuverte]);
+  }, [principaleReady, sessionCaisseOuverte, refreshCaisseSecondaire]);
 
   const markSecondaryOpen = (id) => {
   setUuidCaisseSecondaire(id);

--- a/frontend/src/pages/Caisse.jsx
+++ b/frontend/src/pages/Caisse.jsx
@@ -7,7 +7,7 @@ import BoutonsCaisse from '../components/BoutonsCaisse';
 import TicketVente from '../components/TicketVente';
 import ValidationVente from '../components/ValidationVente';
 import { toast } from 'react-toastify';
-import { useLocation, Link } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { useActiveSession } from '../contexts/SessionCaisseContext';
 import { useConfirm } from "../contexts/ConfirmContext";
 
@@ -22,8 +22,6 @@ function Caisse() {
   const [ventes, setVentes] = useState([]);
   const [venteActive, setVenteActive] = useState(null);
   const [ouvert, setOuvert] = useState(false);
-  const sessionCaisseOuverte = activeSession;
-
     console.log("🧪 activeSession:", activeSession);
 
 

--- a/frontend/src/pages/FermetureCaisse.jsx
+++ b/frontend/src/pages/FermetureCaisse.jsx
@@ -7,7 +7,6 @@ import BilanSessionCaisse from '../components/BilanSessionCaisse';
 import BilanReductionsSession from '../components/BilanReductionsSession';
 import TactileInput from '../components/TactileInput';
 import { useActiveSession } from '../contexts/SessionCaisseContext';
-import { set } from 'date-fns';
 import { euro } from '../utils/euro';
 import SiCaissePrincipale from '../utils/SiCaissePrincipale';
 import SiCaisseSecondaire from '../utils/SiCaisseSecondaire';
@@ -163,6 +162,7 @@ function FermetureCaisse() {
 
   // Récupère les montants attendus pour la session de caisse en cours
   useEffect(() => {
+    if (!uuidSessionCaisse) return;
     // Récupération des montants attendus depuis la table "bilan"
     fetch('http://localhost:3001/api/bilan/bilan_session_caisse?uuid_session_caisse=' + uuidSessionCaisse,{credentials: 'include'})
       .then(res => res.json())
@@ -185,7 +185,7 @@ function FermetureCaisse() {
           virement: 0
         });
       });
-  }, []);
+  }, [uuidSessionCaisse]);
 
   // Rendu du composant principal de fermeture de caisse
   return (

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import SignupModal from '../components/SignupModal';
 import { useSession } from '../contexts/SessionContext'; // ✅

--- a/frontend/src/pages/Parametres.jsx
+++ b/frontend/src/pages/Parametres.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Form, Button, Collapse } from 'react-bootstrap';
 import BoutonsManager from '../components/BoutonsManager';
-import ResetButton from '../components/ResetButton';
 import DevModeToggle from '../components/DevModeToggle';
 import DevModeModal from '../components/DevModeModal';
 import { useContext } from 'react';

--- a/frontend/src/pages/ouvertureCaisse.jsx
+++ b/frontend/src/pages/ouvertureCaisse.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import CompteEspeces from '../components/compteEspeces';
 import TactileInput from '../components/TactileInput';
@@ -115,11 +114,6 @@ function OuvertureCaisse() {
         setMessage('Erreur de communication avec le serveur.');
       }
     }
-  };
-
-  // Guard pour CompteEspeces: ne prend la main que si non secondaire
-  const handleEspecesChange = (total) => {
-    if (!isSecondaire) setFondInitial(total);
   };
 
   return (

--- a/frontend/src/utils/SiCaisseOuverte.jsx
+++ b/frontend/src/utils/SiCaisseOuverte.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useActiveSession } from "../contexts/SessionCaisseContext";
 
 /**

--- a/frontend/src/utils/SiCaissePrincipale.jsx
+++ b/frontend/src/utils/SiCaissePrincipale.jsx
@@ -1,4 +1,3 @@
-import { jsx } from "react/jsx-runtime";
 import { useActiveSession } from "../contexts/SessionCaisseContext"
 
 export const SiCaissePrincipale = ({ children }) => {

--- a/frontend/src/utils/SiCaisseSecondaire.jsx
+++ b/frontend/src/utils/SiCaisseSecondaire.jsx
@@ -1,4 +1,3 @@
-import { jsx } from "react/jsx-runtime";
 import { useActiveSession } from "../contexts/SessionCaisseContext"
 
 export const SiCaisseSecondaire = ({ children }) => {


### PR DESCRIPTION
### Motivation
- Make the Electron release/publish flow clearer and fail faster when required environment variables are missing to avoid long wasted builds. 
- Prevent stalled WebDAV uploads from hanging the publish step and reduce noisy CRA sourcemap warnings during packaged builds. 
- Remove unused imports/variables and fix hook/update patterns so the React production build compiles without avoidable warnings.

### Description
- Enhance `electron-app/scripts/build-release.js` to print build progress messages, validate `BDD_CAISSE_UPDATE_URL` early when `--publish` is requested, and add a configurable upload timeout controlled by `BDD_CAISSE_UPLOAD_TIMEOUT_MS` (default 120s). 
- Add `frontend/.env.production` with `GENERATE_SOURCEMAP=false` to disable generation of production sourcemaps and avoid missing-dependency sourcemap warnings from CRA builds. 
- Clean up frontend code by removing unused imports/variables, fixing effect dependencies and using functional state updates where appropriate (notably in `CorrectionModal.jsx` and `SessionCaisseContext.js`), and small import fixes across several components to eliminate ESLint warnings. 

### Testing
- Ran `npm run build` and the CRA frontend compiled successfully (production build created). 
- Ran `cd electron-app && env -u BDD_CAISSE_UPDATE_URL npm run release:publish` and verified it fails fast with the expected error about `BDD_CAISSE_UPDATE_URL`. 
- Ran `cd electron-app && npm run release:no-publish` which reached `electron-builder` successfully but full packaging could not complete in this environment because Electron download from GitHub returned `403 Forbidden` (external hosting restriction), so packaging failed due to the environment rather than the script changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0232944da08327ac482d15455d68d4)