### PR TITLE
Add invoice (factures) support, switch SMTP to Gmail, and refactor WebDAV sync to include invoices

### DIFF
--- a/backend/README_FACTURES.md
+++ b/backend/README_FACTURES.md
@@ -1,0 +1,7 @@
+# Factures : stockage et envoi email
+
+- Les PDF de factures sont générés dans le dossier utilisateur :
+  `~/.bdd-caisse/factures/<YYYY>/<MM>/<DD>`.
+- Le backend expose ce dossier via la route statique `/factures`.
+- L'envoi d'une facture se fait via SMTP Gmail (`smtp.gmail.com`, port `465`, `secure: true`) avec l'expéditeur `magasin@ressourcebrie.fr`.
+- La synchro WebDAV envoie aussi les factures avec la même arborescence de dates que les tickets, dans le dossier distant `/factures`.

--- a/backend/routes/envoiTicket.routes.js
+++ b/backend/routes/envoiTicket.routes.js
@@ -6,16 +6,12 @@ const nodemailer = require('nodemailer');
 const fs = require('fs');
 
 const transporter = nodemailer.createTransport({
-  host: 'smtp.ouvaton.coop',
-  port: 587,
-  secure: false, // STARTTLS
+  host: 'smtp.gmail.com',
+  port: 465,
+  secure: true,
   auth: {
     user: 'magasin@ressourcebrie.fr',
     pass: 'Magasin7#'
-  },
-  tls: {
-    ciphers: 'SSLv3',
-    rejectUnauthorized: false
   },
   logger: true,
   debug: true

--- a/backend/routes/facture.routes.js
+++ b/backend/routes/facture.routes.js
@@ -9,16 +9,12 @@ const nodemailer = require('nodemailer');
 const logSync = require('../logsync');
 
 const transporter = nodemailer.createTransport({
-  host: 'smtp.ouvaton.coop',
-  port: 587,
-  secure: false,
+  host: 'smtp.gmail.com',
+  port: 465,
+  secure: true,
   auth: {
     user: 'magasin@ressourcebrie.fr',
     pass: 'Magasin7#'
-  },
-  tls: {
-    ciphers: 'SSLv3',
-    rejectUnauthorized: false
   }
 });
 

--- a/backend/routes/validerVente.routes.js
+++ b/backend/routes/validerVente.routes.js
@@ -16,16 +16,12 @@ const genererTicketPdf = require('../utils/genererTicketPdf');
 
 // Configuration du transporteur d'emails (SMTP)
 const transporter = nodemailer.createTransport({
-  host: 'smtp.ouvaton.coop',
-  port: 587,
-  secure: false,
+  host: 'smtp.gmail.com',
+  port: 465,
+  secure: true,
   auth: {
     user: 'magasin@ressourcebrie.fr',
     pass: 'Magasin7#'
-  },
-  tls: {
-    ciphers: 'SSLv3',
-    rejectUnauthorized: false
   },
   logger: true,
   debug: true

--- a/backend/webdavScheduler.js
+++ b/backend/webdavScheduler.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const cron = require('node-cron');
-const { uploadTickets } = require('./webdavSync');
+const { uploadTicketsAndFactures } = require('./webdavSync');
 const { getWebdavConfig, updateWebdavConfig, getActiveCredentials } = require('./webdavConfig');
 
 const baseDir = path.join(os.homedir(), '.bdd-caisse');
@@ -25,7 +25,7 @@ async function runSync() {
   isRunning = true;
   const start = new Date();
   try {
-    const count = await uploadTickets();
+    const count = await uploadTicketsAndFactures();
     const end = new Date();
     saveState({ lastRun: start.toISOString(), lastDurationMs: end - start, lastResult: 'success', lastCount: count });
     return { success: true, count };

--- a/backend/webdavSync.js
+++ b/backend/webdavSync.js
@@ -6,6 +6,7 @@ const { getActiveCredentials } = require('./webdavConfig');
 
 const baseDir = path.join(os.homedir(), '.bdd-caisse');
 const ticketsDir = path.join(baseDir, 'tickets');
+const facturesDir = path.join(baseDir, 'factures');
 
 // -------- 1. Fonction récursive pour lister tous les fichiers --------
 async function listLocalFiles(rootDir) {
@@ -215,6 +216,39 @@ async function runWithConcurrency(items, limit, worker) {
 }
 
 
+async function uploadDirectory({ label, localDir, baseUrl, headers, remoteBasePath }) {
+  const files = await listLocalFiles(localDir);
+  console.log(`📦 ${label}: ${files.length} fichiers détectés en local.`);
+
+  if (files.length === 0) {
+    return { success: 0, failed: 0, total: 0 };
+  }
+
+  // 1) Créer tous les dossiers nécessaires
+  await createAllRemoteDirs(baseUrl, headers, files, remoteBasePath);
+
+  // 2) Uploader les fichiers
+  const base = remoteBasePath;
+
+  const results = await runWithConcurrency(
+    files,
+    3, // 3 uploads en parallèle pour commencer
+    async file => {
+      const remotePath = normalizeRemotePath(base, file.relPath);
+      const targetUrl = buildRemoteUrl(baseUrl, remotePath);
+      return uploadWithRetry(targetUrl, file.absPath, headers);
+    }
+  );
+
+  const success = results.filter(r => r === true).length;
+  const failed = results.filter(r => r === false).length;
+
+  console.log(`✅ ${label}: Upload OK ${success} fichiers`);
+  console.log(`❌ ${label}: Échecs ${failed}`);
+
+  return { success, failed, total: files.length };
+}
+
 // -------- 7. Version optimisée de uploadTickets --------
 async function uploadTickets() {
   const credentials = getActiveCredentials();
@@ -224,33 +258,38 @@ async function uploadTickets() {
 
   const { url, username, password, basePath } = credentials;
   const headers = buildAuthHeader(username, password);
-
-  const files = await listLocalFiles(ticketsDir);
-  console.log(`📦 ${files.length} fichiers détectés en local.`);
-
-  // 1) Créer tous les dossiers nécessaires
-  await createAllRemoteDirs(url, headers, files, basePath);
-
-  // 2) Uploader les fichiers
-  const base = basePath || '/tickets';
-
-  const results = await runWithConcurrency(
-    files,
-    3, // 3 uploads en parallèle pour commencer
-    async file => {
-      const remotePath = normalizeRemotePath(base, file.relPath);
-      const targetUrl = buildRemoteUrl(url, remotePath);
-      return uploadWithRetry(targetUrl, file.absPath, headers);
-    }
-  );
-
-  const success = results.filter(r => r === true).length;
-  const failed = results.filter(r => r === false).length;
-
-  console.log(`✅ Upload OK : ${success} fichiers`);
-  console.log(`❌ Échecs : ${failed}`);
-
-  return { success, failed };
+  const ticketsBasePath = basePath || '/tickets';
+  return uploadDirectory({
+    label: 'tickets',
+    localDir: ticketsDir,
+    baseUrl: url,
+    headers,
+    remoteBasePath: ticketsBasePath
+  });
 }
 
-module.exports = { uploadTickets };
+async function uploadFactures() {
+  const credentials = getActiveCredentials();
+  if (!credentials) {
+    throw new Error('Aucun profil WebDAV actif trouvé. Vérifiez WEBDAV_ENDPOINTS.');
+  }
+
+  const { url, username, password } = credentials;
+  const headers = buildAuthHeader(username, password);
+
+  return uploadDirectory({
+    label: 'factures',
+    localDir: facturesDir,
+    baseUrl: url,
+    headers,
+    remoteBasePath: '/factures'
+  });
+}
+
+async function uploadTicketsAndFactures() {
+  const tickets = await uploadTickets();
+  const factures = await uploadFactures();
+  return { tickets, factures };
+}
+
+module.exports = { uploadTickets, uploadFactures, uploadTicketsAndFactures };


### PR DESCRIPTION
### Motivation
- Centralize invoice PDF storage and delivery and ensure invoices are synchronized to WebDAV with the same date-based tree as tickets.
- Standardize email sending using the store Gmail SMTP account and remove the previous SMTP provider configuration.
- Improve and generalize the WebDAV upload logic to support both `tickets` and `factures` with better concurrency and clearer results.

### Description
- Added `backend/README_FACTURES.md` documenting local invoice storage under `~/.bdd-caisse/factures/<YYYY>/<MM>/<DD>`, static route `/factures`, SMTP settings (`smtp.gmail.com`, port `465`, `secure: true`, sender `magasin@ressourcebrie.fr`) and WebDAV remote folder `/factures`.
- Updated SMTP configuration in `backend/routes/envoiTicket.routes.js`, `backend/routes/facture.routes.js`, and `backend/routes/validerVente.routes.js` to use Gmail (`host: 'smtp.gmail.com'`, `port: 465`, `secure: true`) and the `magasin@ressourcebrie.fr` credentials, removing the previous `tls` overrides.
- Refactored `backend/webdavSync.js` to add `facturesDir`, a generic `uploadDirectory` helper, and separate `uploadTickets`, `uploadFactures`, and `uploadTicketsAndFactures` functions; adjusted remote URL and directory creation calls to use `baseUrl`/`remoteBasePath` and return structured upload results.
- Updated `backend/webdavScheduler.js` to call `uploadTicketsAndFactures` so both tickets and invoices are synchronized on schedule, and exported the new functions from `webdavSync`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb8df49c008327b931565d71e25f7c)